### PR TITLE
fix: pin SPC to v2.8.4 to resolve musl-toolchain download failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
 
       - name: Download SPC binary
         run: |
-          curl -fsSL "https://github.com/crazywhalecc/static-php-cli/releases/latest/download/${{ matrix.spc-binary }}.tar.gz" \
+          curl -fsSL "https://github.com/crazywhalecc/static-php-cli/releases/download/2.8.4/${{ matrix.spc-binary }}.tar.gz" \
             -o spc.tar.gz
           tar -xzf spc.tar.gz
           chmod +x ./spc


### PR DESCRIPTION
Using 'latest' caused a 500 error downloading musl-toolchain-x86_64-linux in v2.8.3. Pin to v2.8.4 which includes the fix.

Closes #16