### PR TITLE
feat: add --all-columns flag to cloning:dump

### DIFF
--- a/app/Commands/Cloning/DumpCommand.php
+++ b/app/Commands/Cloning/DumpCommand.php
@@ -33,6 +33,7 @@ class DumpCommand extends Command
         {--output=      : Output file path (default: <connection-name>.cloning.yaml)}
         {--force        : Overwrite an existing file without asking}
         {--only-pii     : Omit tables/columns with no PII match}
+        {--all-columns  : Include all columns in the YAML, not just PII-detected ones}
         {--locale=      : FakerPHP locale for options.faker_locale (default: en_US)}
         {--ci           : CI mode — suppress non-error output}';
 
@@ -55,6 +56,14 @@ class DumpCommand extends Command
         }
 
         $ci = (bool) $this->option('ci');
+        $onlyPii = (bool) $this->option('only-pii');
+        $allColumns = (bool) $this->option('all-columns');
+
+        if ($allColumns && $onlyPii) {
+            $this->error('--all-columns and --only-pii cannot be used together.');
+
+            return ExitCode::ValidationError->value;
+        }
 
         // 2. Resolve connection
         $connectionOption = $this->option('connection');
@@ -139,7 +148,6 @@ class DumpCommand extends Command
         // 8. Build table dump data
         $localeOption = $this->option('locale');
         $fakerLocale = is_string($localeOption) && $localeOption !== '' ? $localeOption : 'en_US';
-        $onlyPii = (bool) $this->option('only-pii');
 
         $tableDumps = [];
         $piiColumnsDetected = 0;
@@ -235,6 +243,7 @@ class DumpCommand extends Command
             outputPath: $outputPath,
             fakerLocale: $fakerLocale,
             keyRemapping: $onlyPii ? null : $this->buildKeyRemapping($schema),
+            includeKeepColumns: $allColumns,
         );
 
         // 11. Write YAML

--- a/app/Data/Cloning/DumpResultData.php
+++ b/app/Data/Cloning/DumpResultData.php
@@ -15,5 +15,6 @@ final readonly class DumpResultData
         public string $outputPath,
         public string $fakerLocale = 'en_US',
         public ?KeyRemappingConfigData $keyRemapping = null,
+        public bool $includeKeepColumns = false,
     ) {}
 }

--- a/app/Services/Cloning/CloningYamlWriter.php
+++ b/app/Services/Cloning/CloningYamlWriter.php
@@ -46,10 +46,12 @@ class CloningYamlWriter
 
             $krTable = $result->keyRemapping?->getTable($table->name);
 
-            $nonKeepColumns = array_filter(
-                $table->columns,
-                static fn (ColumnDumpData $col): bool => $col->strategy !== 'keep'
-            );
+            $nonKeepColumns = $result->includeKeepColumns
+                ? $table->columns
+                : array_filter(
+                    $table->columns,
+                    static fn (ColumnDumpData $col): bool => $col->strategy !== 'keep'
+                );
 
             if ($nonKeepColumns === [] && ! $krTable instanceof KeyRemappingTableData) {
                 $lines[] = '    # no PII detected — no columns listed; all kept as-is';
@@ -112,6 +114,10 @@ class CloningYamlWriter
 
                         case 'static':
                             $lines[] = sprintf('        value: %s', $this->encodeYamlScalar($column->staticValue));
+                            break;
+
+                        case 'keep':
+                            // no extra fields needed
                             break;
                     }
                 }

--- a/tests/Feature/Commands/Cloning/DumpCommandTest.php
+++ b/tests/Feature/Commands/Cloning/DumpCommandTest.php
@@ -352,6 +352,64 @@ it('omits key_remapping section when no integer primary keys exist', function ()
     expect($yaml)->not->toContain('strategy: remapping');
 });
 
+it('--all-columns includes keep-strategy columns in the YAML', function (): void {
+    Storage::fake('local');
+
+    $connection = makeDumpMysqlConnection('production-db');
+    $schema = makeSimpleSchema(); // has id, email, password, created_at
+    $piiSet = makePiiMatcherSet();
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('exists')->andReturn(true);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn($connection);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($schema);
+
+    $piiLoader = Mockery::mock(PiiMatcherLoader::class);
+    $piiLoader->shouldReceive('load')->andReturn($piiSet);
+
+    $this->app->instance(ConfigService::class, $config);
+    $this->app->instance(SchemaInspector::class, $inspector);
+    $this->app->instance(PiiMatcherLoader::class, $piiLoader);
+
+    $this->artisan('cloning:dump', [
+        '--connection' => 'production-db',
+        '--all-columns' => true,
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+
+    $yaml = Storage::disk('local')->get('production-db.cloning.yaml');
+    expect($yaml)->toBeString();
+    // PII columns still present
+    expect($yaml)->toContain('email:');
+    expect($yaml)->toContain('strategy: fake');
+    // Keep columns now also present
+    expect($yaml)->toContain('created_at:');
+    expect($yaml)->toContain('strategy: keep');
+    // No 'no PII detected' comment since columns are explicitly listed
+    expect($yaml)->not->toContain('# no PII detected');
+});
+
+it('--all-columns and --only-pii together return ValidationError', function (): void {
+    Storage::fake('local');
+
+    $connection = makeDumpMysqlConnection('production-db');
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('exists')->andReturn(true);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn($connection);
+
+    $this->app->instance(ConfigService::class, $config);
+
+    $this->artisan('cloning:dump', [
+        '--connection' => 'production-db',
+        '--all-columns' => true,
+        '--only-pii' => true,
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::ValidationError->value);
+});
+
 it('only-pii: only includes PII columns and tables', function (): void {
     Storage::fake('local');
 


### PR DESCRIPTION
When --all-columns is passed, the generated YAML lists every column explicitly (including strategy: keep) rather than only PII-detected ones. Useful when the user wants to review or adjust all column strategies before running cloning:run.

--all-columns and --only-pii are mutually exclusive and return ValidationError(4) when combined.

Closes #11