### PR TITLE
feat(schema): diff source vs target schema in dry-run and verbose mode

### DIFF
--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -13,6 +13,7 @@ use App\Data\Cloning\TableCloningConfigData;
 use App\Data\Cloning\TableRunResultData;
 use App\Data\Cloning\TableRunStatus;
 use App\Data\ConnectionData;
+use App\Data\Schema\SchemaDiffData;
 use App\Enums\ExitCode;
 use App\Services\Audit\AuditDeliveryService;
 use App\Services\Audit\AuditLogBuilder;
@@ -28,6 +29,7 @@ use App\Services\Cloning\KeyRemappingService;
 use App\Services\Cloning\RunLogWriter;
 use App\Services\Config\ConfigService;
 use App\Services\Database\DatabaseConnectionService;
+use App\Services\Schema\SchemaDiffService;
 use App\Services\Schema\SchemaInspector;
 use DateTimeImmutable;
 use DateTimeZone;
@@ -227,7 +229,7 @@ class RunCommand extends Command
 
         // ─── Phase 3: Dry-run ──────────────────────────────────────────────────
         if ((bool) $this->option('dry-run')) {
-            return $this->runDryRun($config, $sourceConnection, $inspector, $ci);
+            return $this->runDryRun($config, $sourceConnection, $targetConnection, $inspector, $ci);
         }
 
         // ─── Phase 4-6: Full Run ───────────────────────────────────────────────
@@ -271,6 +273,35 @@ class RunCommand extends Command
         }
 
         $skipSchema = (bool) $this->option('skip-schema');
+
+        if ($verbose) {
+            try {
+                $targetSchema = $inspector->inspect($targetConnection);
+                $schemaDiff = (new SchemaDiffService)->diff($sourceSchema, $targetSchema);
+
+                if ($schemaDiff->hasDifferences()) {
+                    $parts = [];
+
+                    if ($schemaDiff->missingTables !== []) {
+                        $parts[] = count($schemaDiff->missingTables).' missing';
+                    }
+
+                    if ($schemaDiff->modifiedTables !== []) {
+                        $parts[] = count($schemaDiff->modifiedTables).' modified';
+                    }
+
+                    if ($schemaDiff->extraTables !== []) {
+                        $parts[] = count($schemaDiff->extraTables).' extra on target';
+                    }
+
+                    $this->line(sprintf('  <comment>~</comment>  Schema diff: %s', implode(', ', $parts)));
+                } else {
+                    $this->line('  <info>✓</info>  Schema diff: target matches source');
+                }
+            } catch (Throwable) {
+                // non-fatal: skip diff output if target schema cannot be inspected
+            }
+        }
 
         if ($verbose && ! $skipSchema) {
             $this->line('  <info>✓</info>  Replicating schema ...');
@@ -438,6 +469,7 @@ class RunCommand extends Command
     private function runDryRun(
         CloningConfigData $config,
         ConnectionData $source,
+        ConnectionData $target,
         SchemaInspector $inspector,
         bool $ci,
     ): int {
@@ -447,6 +479,15 @@ class RunCommand extends Command
             $this->error(sprintf('Failed to inspect source schema: %s', $throwable->getMessage()));
 
             return ExitCode::ConnectionError->value;
+        }
+
+        $schemaDiff = null;
+
+        try {
+            $targetSchema = $inspector->inspect($target);
+            $schemaDiff = (new SchemaDiffService)->diff($schema, $targetSchema);
+        } catch (Throwable) {
+            // non-fatal: proceed without diff if target cannot be inspected
         }
 
         /** @var list<DryRunTableData> $dryRunTables */
@@ -461,9 +502,6 @@ class RunCommand extends Command
 
             if ($exists) {
                 try {
-                    $sourceConnName = null;
-                    // We need a connection to count rows
-                    // Use SchemaInspector's connector indirectly
                     $estimatedRows = $this->countRows($source, $tableName);
                 } catch (Throwable) {
                     $estimatedRows = null;
@@ -505,7 +543,7 @@ class RunCommand extends Command
         );
 
         if (! $ci) {
-            $this->renderDryRunTable($dryRunResult, $config->connectionName);
+            $this->renderDryRunTable($dryRunResult, $config->connectionName, $schemaDiff);
         }
 
         return ExitCode::Success->value;
@@ -546,11 +584,56 @@ class RunCommand extends Command
         }
     }
 
-    private function renderDryRunTable(DryRunResultData $result, string $sourceName): void
+    private function renderSchemaDiff(SchemaDiffData $diff): void
+    {
+        if ($diff->isIdentical()) {
+            $this->line('  Schema diff: target matches source');
+            $this->line('');
+
+            return;
+        }
+
+        $this->line('  Schema diff: source → target');
+        $this->line('');
+
+        if ($diff->missingTables !== []) {
+            $this->line(sprintf('  Missing tables (%d):   %s', count($diff->missingTables), implode(', ', $diff->missingTables)));
+        }
+
+        if ($diff->extraTables !== []) {
+            $this->line(sprintf('  Extra tables (%d):     %s', count($diff->extraTables), implode(', ', $diff->extraTables)));
+        }
+
+        foreach ($diff->modifiedTables as $tableDiff) {
+            $parts = [];
+
+            if ($tableDiff->missingColumns !== []) {
+                $parts[] = sprintf('+%d col%s (%s)', count($tableDiff->missingColumns), count($tableDiff->missingColumns) === 1 ? '' : 's', implode(', ', $tableDiff->missingColumns));
+            }
+
+            if ($tableDiff->extraColumns !== []) {
+                $parts[] = sprintf('-%d col%s (%s)', count($tableDiff->extraColumns), count($tableDiff->extraColumns) === 1 ? '' : 's', implode(', ', $tableDiff->extraColumns));
+            }
+
+            foreach ($tableDiff->modifiedColumns as $colDiff) {
+                $parts[] = sprintf('~%s (%s → %s%s)', $colDiff->name, $colDiff->sourceType, $colDiff->targetType, $colDiff->sourceNullable !== $colDiff->targetNullable ? ', nullable changed' : '');
+            }
+
+            $this->line(sprintf('  Modified table:        %s: %s', $tableDiff->tableName, implode(', ', $parts)));
+        }
+
+        $this->line('');
+    }
+
+    private function renderDryRunTable(DryRunResultData $result, string $sourceName, ?SchemaDiffData $schemaDiff = null): void
     {
         $this->line('');
         $this->line(sprintf('  Dry-run: %s', $sourceName));
         $this->line('');
+
+        if ($schemaDiff instanceof SchemaDiffData) {
+            $this->renderSchemaDiff($schemaDiff);
+        }
 
         $tableWidth = 24;
         $rowsWidth = 14;

--- a/app/Data/Schema/ColumnDiffData.php
+++ b/app/Data/Schema/ColumnDiffData.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Schema;
+
+final readonly class ColumnDiffData
+{
+    public function __construct(
+        public string $name,
+        public string $sourceType,
+        public string $targetType,
+        public bool $sourceNullable,
+        public bool $targetNullable,
+    ) {}
+}

--- a/app/Data/Schema/SchemaDiffData.php
+++ b/app/Data/Schema/SchemaDiffData.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Schema;
+
+final readonly class SchemaDiffData
+{
+    /**
+     * @param  list<string>  $missingTables  Tables in source but not in target
+     * @param  list<string>  $extraTables  Tables in target but not in source
+     * @param  list<TableDiffData>  $modifiedTables  Tables with structural differences
+     */
+    public function __construct(
+        public array $missingTables,
+        public array $extraTables,
+        public array $modifiedTables,
+    ) {}
+
+    public function hasDifferences(): bool
+    {
+        return $this->missingTables !== [] || $this->extraTables !== [] || $this->modifiedTables !== [];
+    }
+
+    public function isIdentical(): bool
+    {
+        return ! $this->hasDifferences();
+    }
+}

--- a/app/Data/Schema/TableDiffData.php
+++ b/app/Data/Schema/TableDiffData.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Schema;
+
+final readonly class TableDiffData
+{
+    /**
+     * @param  list<string>  $missingColumns  Columns in source but not in target
+     * @param  list<string>  $extraColumns  Columns in target but not in source
+     * @param  list<ColumnDiffData>  $modifiedColumns  Columns with type/nullability differences
+     */
+    public function __construct(
+        public string $tableName,
+        public array $missingColumns,
+        public array $extraColumns,
+        public array $modifiedColumns,
+    ) {}
+
+    public function hasDifferences(): bool
+    {
+        return $this->missingColumns !== [] || $this->extraColumns !== [] || $this->modifiedColumns !== [];
+    }
+}

--- a/app/Services/Schema/SchemaDiffService.php
+++ b/app/Services/Schema/SchemaDiffService.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Schema;
+
+use App\Data\Schema\ColumnDiffData;
+use App\Data\Schema\ColumnSchemaData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\SchemaDiffData;
+use App\Data\Schema\TableDiffData;
+use App\Data\Schema\TableSchemaData;
+
+final class SchemaDiffService
+{
+    public function diff(DatabaseSchemaData $source, DatabaseSchemaData $target): SchemaDiffData
+    {
+        $missingTables = [];
+        $modifiedTables = [];
+
+        foreach ($source->tables as $sourceTable) {
+            $targetTable = $target->getTable($sourceTable->name);
+
+            if (! $targetTable instanceof TableSchemaData) {
+                $missingTables[] = $sourceTable->name;
+            } else {
+                $tableDiff = $this->diffTable($sourceTable, $targetTable);
+
+                if ($tableDiff->hasDifferences()) {
+                    $modifiedTables[] = $tableDiff;
+                }
+            }
+        }
+
+        $extraTables = [];
+
+        foreach ($target->tables as $targetTable) {
+            if (! $source->hasTable($targetTable->name)) {
+                $extraTables[] = $targetTable->name;
+            }
+        }
+
+        return new SchemaDiffData(
+            missingTables: $missingTables,
+            extraTables: $extraTables,
+            modifiedTables: $modifiedTables,
+        );
+    }
+
+    private function diffTable(TableSchemaData $source, TableSchemaData $target): TableDiffData
+    {
+        $missingColumns = [];
+        $modifiedColumns = [];
+
+        foreach ($source->columns as $sourceColumn) {
+            $targetColumn = $this->findColumn($target, $sourceColumn->name);
+
+            if (! $targetColumn instanceof ColumnSchemaData) {
+                $missingColumns[] = $sourceColumn->name;
+            } elseif ($this->columnsAreDifferent($sourceColumn, $targetColumn)) {
+                $modifiedColumns[] = new ColumnDiffData(
+                    name: $sourceColumn->name,
+                    sourceType: $sourceColumn->type,
+                    targetType: $targetColumn->type,
+                    sourceNullable: $sourceColumn->nullable,
+                    targetNullable: $targetColumn->nullable,
+                );
+            }
+        }
+
+        $extraColumns = [];
+
+        foreach ($target->columns as $targetColumn) {
+            if (! $this->findColumn($source, $targetColumn->name) instanceof ColumnSchemaData) {
+                $extraColumns[] = $targetColumn->name;
+            }
+        }
+
+        return new TableDiffData(
+            tableName: $source->name,
+            missingColumns: $missingColumns,
+            extraColumns: $extraColumns,
+            modifiedColumns: $modifiedColumns,
+        );
+    }
+
+    private function findColumn(TableSchemaData $table, string $name): ?ColumnSchemaData
+    {
+        foreach ($table->columns as $column) {
+            if ($column->name === $name) {
+                return $column;
+            }
+        }
+
+        return null;
+    }
+
+    private function columnsAreDifferent(ColumnSchemaData $source, ColumnSchemaData $target): bool
+    {
+        return strtolower($source->type) !== strtolower($target->type)
+            || $source->nullable !== $target->nullable;
+    }
+}

--- a/tests/Feature/Commands/Cloning/RunCommandTest.php
+++ b/tests/Feature/Commands/Cloning/RunCommandTest.php
@@ -690,3 +690,125 @@ YAML;
         ->expectsOutputToContain('Cannot connect')
         ->assertExitCode(ExitCode::ConnectionError->value);
 });
+
+it('dry-run shows schema diff when target is missing tables', function (): void {
+    Storage::fake('local');
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $sourceSchema = new DatabaseSchemaData(
+        databaseName: 'mydb',
+        tables: [
+            new TableSchemaData(
+                name: 'users',
+                columns: [
+                    new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true),
+                    new ColumnSchemaData(name: 'email', type: 'varchar', nullable: false, default: null, isPrimary: false),
+                ],
+                foreignKeys: [],
+            ),
+            new TableSchemaData(
+                name: 'orders',
+                columns: [
+                    new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true),
+                ],
+                foreignKeys: [],
+            ),
+        ],
+    );
+
+    $targetSchema = new DatabaseSchemaData(
+        databaseName: 'stagingdb',
+        tables: [
+            new TableSchemaData(
+                name: 'users',
+                columns: [
+                    new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true),
+                    new ColumnSchemaData(name: 'email', type: 'varchar', nullable: false, default: null, isPrimary: false),
+                ],
+                foreignKeys: [],
+            ),
+        ],
+    );
+
+    $callCount = 0;
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturnUsing(static function () use (&$callCount, $sourceSchema, $targetSchema) {
+        $callCount++;
+
+        return $callCount === 1 ? $sourceSchema : $targetSchema;
+    });
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--dry-run' => true,
+    ])
+        ->expectsOutputToContain('Schema diff')
+        ->assertExitCode(ExitCode::Success->value);
+
+    expect($callCount)->toBe(2);
+});
+
+it('dry-run shows identical schema message when schemas match', function (): void {
+    Storage::fake('local');
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn(makeRunSimpleSchema());
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--dry-run' => true,
+    ])
+        ->expectsOutputToContain('target matches source')
+        ->assertExitCode(ExitCode::Success->value);
+});

--- a/tests/Unit/Services/Schema/SchemaDiffServiceTest.php
+++ b/tests/Unit/Services/Schema/SchemaDiffServiceTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\Schema\ColumnSchemaData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\TableSchemaData;
+use App\Services\Schema\SchemaDiffService;
+
+function diffSchemaWith(string $dbName, array $tables): DatabaseSchemaData
+{
+    return new DatabaseSchemaData(databaseName: $dbName, tables: $tables);
+}
+
+function diffTable(string $name, array $columns, array $foreignKeys = []): TableSchemaData
+{
+    return new TableSchemaData(name: $name, columns: $columns, foreignKeys: $foreignKeys);
+}
+
+function diffColumn(string $name, string $type = 'int', bool $nullable = false): ColumnSchemaData
+{
+    return new ColumnSchemaData(name: $name, type: $type, nullable: $nullable, default: null, isPrimary: false);
+}
+
+it('reports identical schemas as having no differences', function (): void {
+    $schema = diffSchemaWith('db', [
+        diffTable('users', [
+            diffColumn('id', 'int'),
+            diffColumn('email', 'varchar'),
+        ]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($schema, $schema);
+
+    expect($diff->isIdentical())->toBeTrue()
+        ->and($diff->missingTables)->toBe([])
+        ->and($diff->extraTables)->toBe([])
+        ->and($diff->modifiedTables)->toBe([]);
+});
+
+it('detects tables present in source but missing in target', function (): void {
+    $source = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id')]),
+        diffTable('orders', [diffColumn('id')]),
+    ]);
+
+    $target = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id')]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->missingTables)->toBe(['orders'])
+        ->and($diff->extraTables)->toBe([])
+        ->and($diff->modifiedTables)->toBe([]);
+});
+
+it('detects tables present in target but not in source', function (): void {
+    $source = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id')]),
+    ]);
+
+    $target = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id')]),
+        diffTable('legacy_data', [diffColumn('id')]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->extraTables)->toBe(['legacy_data'])
+        ->and($diff->missingTables)->toBe([]);
+});
+
+it('detects missing columns in a shared table', function (): void {
+    $source = diffSchemaWith('db', [
+        diffTable('users', [
+            diffColumn('id'),
+            diffColumn('email', 'varchar'),
+            diffColumn('phone', 'varchar'),
+        ]),
+    ]);
+
+    $target = diffSchemaWith('db', [
+        diffTable('users', [
+            diffColumn('id'),
+            diffColumn('email', 'varchar'),
+        ]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->modifiedTables)->toHaveCount(1)
+        ->and($diff->modifiedTables[0]->tableName)->toBe('users')
+        ->and($diff->modifiedTables[0]->missingColumns)->toBe(['phone'])
+        ->and($diff->modifiedTables[0]->extraColumns)->toBe([]);
+});
+
+it('detects extra columns on the target table', function (): void {
+    $source = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id')]),
+    ]);
+
+    $target = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id'), diffColumn('legacy_col', 'varchar')]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->modifiedTables)->toHaveCount(1)
+        ->and($diff->modifiedTables[0]->extraColumns)->toBe(['legacy_col'])
+        ->and($diff->modifiedTables[0]->missingColumns)->toBe([]);
+});
+
+it('detects columns with changed types', function (): void {
+    $source = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id', 'int')]),
+    ]);
+
+    $target = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('id', 'bigint')]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->modifiedTables)->toHaveCount(1)
+        ->and($diff->modifiedTables[0]->modifiedColumns)->toHaveCount(1)
+        ->and($diff->modifiedTables[0]->modifiedColumns[0]->name)->toBe('id')
+        ->and($diff->modifiedTables[0]->modifiedColumns[0]->sourceType)->toBe('int')
+        ->and($diff->modifiedTables[0]->modifiedColumns[0]->targetType)->toBe('bigint');
+});
+
+it('detects columns with changed nullability', function (): void {
+    $source = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('email', 'varchar', false)]),
+    ]);
+
+    $target = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('email', 'varchar', true)]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->modifiedTables)->toHaveCount(1)
+        ->and($diff->modifiedTables[0]->modifiedColumns[0]->sourceNullable)->toBeFalse()
+        ->and($diff->modifiedTables[0]->modifiedColumns[0]->targetNullable)->toBeTrue();
+});
+
+it('ignores type case differences (varchar vs VARCHAR)', function (): void {
+    $source = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('email', 'varchar')]),
+    ]);
+
+    $target = diffSchemaWith('db', [
+        diffTable('users', [diffColumn('email', 'VARCHAR')]),
+    ]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->isIdentical())->toBeTrue();
+});
+
+it('hasDifferences returns true when tables are missing', function (): void {
+    $source = diffSchemaWith('db', [diffTable('users', [diffColumn('id')])]);
+    $target = diffSchemaWith('db', []);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->hasDifferences())->toBeTrue()
+        ->and($diff->isIdentical())->toBeFalse();
+});
+
+it('reports table diff hasDifferences only when columns differ', function (): void {
+    $source = diffSchemaWith('db', [diffTable('users', [diffColumn('id')])]);
+    $target = diffSchemaWith('db', [diffTable('users', [diffColumn('id')])]);
+
+    $diff = (new SchemaDiffService)->diff($source, $target);
+
+    expect($diff->modifiedTables)->toBe([]);
+});


### PR DESCRIPTION
## Summary

- Adds `SchemaDiffService` that computes structural differences between two `DatabaseSchemaData` objects: missing tables, extra tables, and per-table column diffs (missing, extra, type/nullability changes)
- **Dry-run (`--dry-run`)**: inspects both source and target schemas and renders a schema diff block before the per-table row summary — shows missing tables, extra tables on target, and modified columns
- **Verbose full-run (`-v`)**: prints a one-line schema diff summary before schema replication so operators can see what will change at a glance
- Both integration points are non-fatal — if the target schema cannot be inspected (e.g. not yet created), the diff is silently skipped

## New files

- `app/Data/Schema/ColumnDiffData.php`
- `app/Data/Schema/TableDiffData.php`
- `app/Data/Schema/SchemaDiffData.php`
- `app/Services/Schema/SchemaDiffService.php`
- `tests/Unit/Services/Schema/SchemaDiffServiceTest.php` (10 tests)

## Test plan

- [x] `composer test` passes (369 tests)
- [x] `composer lint` passes (Rector + Pint)
- [x] PHPStan level max: no errors
- [x] Unit tests cover all diff cases: identical schemas, missing/extra tables, missing/extra/modified columns, case-insensitive type comparison
- [x] Feature tests verify dry-run shows "Schema diff" output and handles identical schemas

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)