### PR TITLE
feat(init): enhance audit channel creation feedback

### DIFF
--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -103,9 +103,12 @@ class InitCommand extends Command
             'stderr' => ['type' => 'stderr'],
         ];
 
+        $created = [];
+
         foreach ($defaults as $name => $channelConfig) {
             if (! $config->hasAuditChannel($name)) {
                 $config->setAuditChannel($name, $channelConfig);
+                $created[] = $name;
             }
         }
 
@@ -116,6 +119,17 @@ class InitCommand extends Command
                 $config->setAuditDeliverTo($logType, array_merge($current, ['local']));
             }
         }
+
+        if ($created !== []) {
+            $this->info(sprintf(
+                '  ✓  Created clonio.json with default audit channels: %s',
+                implode(', ', $created),
+            ));
+        } else {
+            $this->info('  ✓  Audit channels in clonio.json — ready.');
+        }
+
+        $this->line('');
     }
 
     private function keyInSystemEnv(): bool

--- a/tests/Feature/Commands/InitCommandTest.php
+++ b/tests/Feature/Commands/InitCommandTest.php
@@ -113,6 +113,26 @@ it('replaces APP_KEY in .env when force is confirmed', function (): void {
         ->not->toContain('APP_KEY=base64:oldkey');
 });
 
+it('displays hint about created audit channels on fresh init', function (): void {
+    putenv('APP_KEY');
+    unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
+
+    $this->artisan('init')
+        ->expectsOutputToContain('Created clonio.json with default audit channels: local, stdout, stderr')
+        ->assertExitCode(0);
+});
+
+it('displays ready message when audit channels already exist', function (): void {
+    // APP_KEY already in env from beforeEach
+    // First init creates the channels
+    $this->artisan('init')->assertExitCode(0);
+
+    // Second init should find them already present
+    $this->artisan('init')
+        ->expectsOutputToContain('Audit channels in clonio.json')
+        ->assertExitCode(0);
+});
+
 it('creates default audit channels in clonio.json on fresh init', function (): void {
     putenv('APP_KEY');
     unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);


### PR DESCRIPTION
- Add informative messages for created and existing audit channels during `init` command.
- Extend tests to verify enhanced output behavior.

Closes #23 