### PR TITLE
docs: update docs for all merged features (#49, #52, #53, #54)

### DIFF
--- a/docs/commands/audit-channel.md
+++ b/docs/commands/audit-channel.md
@@ -1,6 +1,6 @@
 # Audit Channel Commands
 
-Manage audit delivery channels in `clonio.json`. Channels define where Clonio sends audit logs and run logs after each operation.
+Manage audit delivery channels in `clonio.json`. Channels define where Clonio sends audit logs and process logs after each operation.
 
 ## Commands
 
@@ -32,8 +32,8 @@ When run without flags the command walks through each field in order:
 1. **Name** — A unique identifier for the channel. Must match `[a-z0-9_-]+` (max 64 chars).
 2. **Type** — Selected from a list of supported channel types.
 3. **Type-specific fields** — Prompted based on the chosen type (see below).
-4. **Deliver audit log** — Whether to add this channel to `audit_log.deliver_to` (default: yes).
-5. **Deliver run log** — Whether to add this channel to `run_log.deliver_to` (default depends on type).
+4. **Deliver audit log** — Whether this channel should deliver the signed HTML audit artefacts (default: yes).
+5. **Deliver process log** — Whether this channel should deliver the JSONL process log (default: yes for `local` and `s3`; no for all other types).
 
 A summary table is displayed before writing. The operation can be cancelled at the final confirmation prompt.
 
@@ -56,10 +56,10 @@ A summary table is displayed before writing. The operation can be cancelled at t
 |---|---|
 | `name` | Channel name (argument, optional) |
 | `--type=` | Channel type: `local`, `s3`, `email`, `ms_teams`, `slack`, `ntfy` |
-| `--deliver-audit-log` | Add channel to `audit_log.deliver_to` |
-| `--no-deliver-audit-log` | Do not add channel to `audit_log.deliver_to` |
-| `--deliver-run-log` | Add channel to `run_log.deliver_to` |
-| `--no-deliver-run-log` | Do not add channel to `run_log.deliver_to` |
+| `--deliver-audit-log` | Enable delivery of the signed HTML audit artefacts via this channel |
+| `--no-deliver-audit-log` | Disable delivery of the signed HTML audit artefacts via this channel |
+| `--deliver-run-log` | Enable delivery of the JSONL process log via this channel |
+| `--no-deliver-run-log` | Disable delivery of the JSONL process log via this channel |
 
 #### Local (`--type=local`)
 
@@ -240,7 +240,7 @@ Lists all configured audit delivery channels and their delivery assignments.
 clonio audit:list
 ```
 
-Outputs a table with columns: **Name**, **Type**, **Audit Log** (✓/✗), **Run Log** (✓/✗), **Details**.
+Outputs a table with columns: **Name**, **Type**, **Audit Log** (✓/✗), **Process Log** (✓/✗), **Details**.
 
 The Details column shows a summary appropriate to the channel type:
 - **Local**: audit log path
@@ -274,6 +274,45 @@ encrypted:<base64-encoded-ciphertext>
 ```
 
 This requires `APP_KEY` to be set in the environment (`.env` or exported). Passing secrets via CLI flags (`--secret-key=`, `--password=`, `--webhook-url=`, `--token=`) is supported but may expose them in shell history — use the interactive prompt instead.
+
+### What each channel delivers
+
+Each channel has independent control over whether it delivers the audit artefacts and the process log:
+
+| Channel type | Audit log (default) | Process log (default) |
+|---|---|---|
+| `local` | Yes | Yes |
+| `s3` | Yes | Yes |
+| `email` | Yes | No |
+| `ms_teams` | Yes | No |
+| `slack` | Yes | No |
+| `ntfy` | Yes | No |
+| `stdout` / `stderr` | Yes | No |
+
+These defaults can be overridden per channel using the `delivers_audit` and `delivers_process_log` boolean keys directly in `clonio.json`:
+
+```json
+{
+  "audit": {
+    "channels": {
+      "local-store": {
+        "type": "local",
+        "path": "./clonio-logs/{year}/{month}",
+        "delivers_audit": true,
+        "delivers_process_log": false
+      },
+      "slack-alerts": {
+        "type": "slack",
+        "webhook_url": "encrypted:...",
+        "delivers_audit": true,
+        "delivers_process_log": true
+      }
+    }
+  }
+}
+```
+
+The `--deliver-audit-log` / `--deliver-run-log` flags in `audit:add` set the delivery assignments at channel-creation time; they cannot yet be changed via `audit:update`. Edit `clonio.json` directly to adjust `delivers_audit` or `delivers_process_log` on an existing channel.
 
 ### clonio.json location
 

--- a/docs/commands/cloning-column-edit.md
+++ b/docs/commands/cloning-column-edit.md
@@ -41,6 +41,34 @@ When run without flags, the command walks through each step interactively:
 
 Available faker methods in the interactive picker: `safeEmail`, `userName`, `name`, `firstName`, `lastName`, `phoneNumber`, `address`, `city`, `postcode`, `countryCode`, `company`, `jobTitle`, `date`, `latitude`, `longitude`, `buildingNumber`, `text`, `sentence`, `url`, `ipv4`, `uuid`, `word`, `numberBetween`, `randomFloat`.
 
+#### Argument hints
+
+After a faker method is selected (interactively or via `--faker-method`), Clonio prints a hint showing what arguments the method accepts:
+
+```
+  ℹ  numberBetween() arguments: min (int, default 0), max (int, default 2147483647)
+```
+
+Methods that take no arguments display:
+
+```
+  ℹ  safeEmail() takes no arguments — leave faker arguments blank.
+```
+
+The argument prompt is skipped automatically for methods with no arguments; the YAML will contain `faker_arguments: []`.
+
+Argument reference for methods that accept parameters:
+
+| Method | Arguments |
+|--------|-----------|
+| `date` | `format` (string, e.g. `"Y-m-d"`), `max` (string\|null, e.g. `"now"`) |
+| `latitude` | `min` (float, default -90), `max` (float, default 90) |
+| `longitude` | `min` (float, default -180), `max` (float, default 180) |
+| `text` | `maxNbChars` (int, default 200) |
+| `sentence` | `nbWords` (int, default 6), `variableNbWords` (bool, default true) |
+| `numberBetween` | `min` (int, default 0), `max` (int, default 2147483647) |
+| `randomFloat` | `nbMaxDecimals` (int\|null), `min` (float, default 0), `max` (float, default 100) |
+
 ### `hash` Parameters
 
 | Parameter | Option | Description |

--- a/docs/commands/cloning-run.md
+++ b/docs/commands/cloning-run.md
@@ -26,6 +26,9 @@ clonio cloning:run <file> [options]
 | `--skip-tables=<list>` | Comma-separated list of table names to exclude from this run |
 | `--only-tables=<list>` | Comma-separated list of table names to include; all others are skipped |
 | `--audit-channel=<list>` | Comma-separated list of channel names to use for this run (overrides `deliver_to` in `clonio.json`) |
+| `--skip-remapping-keys` | Skip key mapping generation and FK rewriting |
+| `--no-memory-limit` | Remove PHP's memory limit before generating key mappings. Useful for very large databases when `--file-based` is not viable. |
+| `--file-based` | Store key mappings in AES-256-CBC encrypted temporary files instead of RAM. Keeps memory usage bounded to the size of the largest single table's mapping. |
 
 `--skip-tables` and `--only-tables` are mutually exclusive. Verbosity flags `-v` / `-vv` / `-vvv` are also supported (see [Output Modes](#output-modes)).
 
@@ -246,6 +249,25 @@ clonio cloning:run production-db.cloning.yaml --target staging --skip-remapping-
 
 Bypasses all key mapping generation and PK/FK rewriting even when the YAML has `strategy: remapping` columns defined.
 
+### Memory management for large databases
+
+By default, all PK mappings are held in RAM simultaneously (one entry per row per remapped table). For most databases this is fast and adequate. For very large datasets two flags are available:
+
+| Flag | Description |
+|------|-------------|
+| `--no-memory-limit` | Removes PHP's `memory_limit` constraint before generating mappings. Useful when the dataset fits on the server but exceeds the configured PHP limit. |
+| `--file-based` | Writes each table's mappings to an AES-256-CBC encrypted temporary file instead of RAM. Only one table's mappings are loaded at a time, keeping peak memory usage bounded to the largest single table. Files are deleted automatically on completion or crash. |
+
+Both flags can be used together if needed. When `--skip-remapping-keys` is set, both flags are silently ignored.
+
+```bash
+# Remove memory cap (dataset fits in RAM, just over the PHP limit)
+clonio cloning:run prod.cloning.yaml --target staging --no-memory-limit
+
+# Encrypt mappings to disk (dataset too large for RAM)
+clonio cloning:run prod.cloning.yaml --target staging --file-based
+```
+
 ### Legacy format (still supported)
 
 The original top-level `key_remapping:` section is still parsed. Existing YAML files do not need to be updated. When both formats are present in the same file, the inline column format takes priority.
@@ -263,7 +285,7 @@ Phase 5  — Dependency Resolution
 Phase 5b — Key Mapping Generation (when remapping columns are defined)
 Phase 6  — Data Transfer
 Phase 7  — Key Mapping Cleanup   (when remapping columns are defined)
-Phase 8  — Audit Log & Run Log
+Phase 8  — Audit Log & Process Log
 Phase 9  — Summary
 ```
 
@@ -317,9 +339,9 @@ The `rows.clear` setting in the YAML config controls whether the target table is
 
 Clearing happens **after** FK checks are disabled, so `TRUNCATE` does not fail on FK-constrained tables (on databases that enforce this restriction at the statement level).
 
-### Phase 7 — Audit Log & Run Log
+### Phase 7 — Audit Log & Process Log
 
-Assembles and signs the HTML audit log and JSONL run log, then delivers both to the configured channels. Skipped silently when `audit` is absent from `clonio.json`.
+Assembles and signs the HTML audit log and JSONL process log, then delivers them to the configured channels according to each channel's delivery settings. Skipped silently when `audit` is absent from `clonio.json`.
 
 ### Phase 8 — Summary
 
@@ -432,12 +454,12 @@ Progress bars are suppressed when `--ci` is active regardless of verbosity level
 | `4` | Validation error — YAML invalid, `--skip-tables` + `--only-tables` combined, or CI without `--target` |
 | `5` | IO error — YAML file not found or not readable |
 
-## Audit & Run Logs
+## Audit & Process Logs
 
-At the end of every successful run, Clonio produces two artefacts:
+At the end of every successful run, Clonio produces two types of artefacts:
 
 - **Audit log** (`*_audit.html` + `*_audit.sig`) — a signed, human-readable document listing all tables, transformations, and transfer counts. Suitable for compliance auditors.
-- **Run log** (`*_run.jsonl`) — a structured, machine-readable execution log with per-table, per-chunk, and per-skipped-row events.
+- **Process log** (`*_process.jsonl`) — a structured, machine-readable JSONL execution log with per-table, per-chunk, and per-skipped-row events recorded during the run.
 
 Files are named using the pattern:
 ```
@@ -448,10 +470,41 @@ For example:
 ```
 production-db_staging_2026-04-01T14-32-00Z_audit.html
 production-db_staging_2026-04-01T14-32-00Z_audit.sig
-production-db_staging_2026-04-01T14-32-00Z_run.jsonl
+production-db_staging_2026-04-01T14-32-00Z_process.jsonl
 ```
 
-Delivery channels (local filesystem, S3-compatible storage, email) are configured in the `audit` block of `clonio.json`. Use `--audit-channel=<name>` to override the configured channels for a single run. If `audit` is absent from `clonio.json`, all delivery is silently skipped.
+### What each channel delivers
+
+Each channel delivers artefacts based on its type and any per-channel overrides in `clonio.json`:
+
+| Channel type | Audit log (default) | Process log (default) |
+|---|---|---|
+| `local` | Yes | Yes |
+| `s3` | Yes | Yes |
+| `email` | Yes | No |
+| `ms_teams` | Yes | No |
+| `slack` | Yes | No |
+| `ntfy` | Yes | No |
+| `stdout` / `stderr` | Yes | No |
+
+Override the defaults for any individual channel with two optional boolean keys in its `clonio.json` entry:
+
+```json
+{
+  "audit": {
+    "channels": {
+      "my-channel": {
+        "type": "local",
+        "path": "./clonio-logs/{year}/{month}",
+        "delivers_audit": true,
+        "delivers_process_log": false
+      }
+    }
+  }
+}
+```
+
+Delivery channels are configured in the `audit` block of `clonio.json`. Use `--audit-channel=<name>` to override which channels are used for a single run. If `audit` is absent from `clonio.json`, all delivery is silently skipped.
 
 Verify the integrity of a stored audit log with `clonio cloning:verify-audit`.
 


### PR DESCRIPTION
## Summary

- **`cloning-run.md`**: Added `--no-memory-limit` and `--file-based` flags to Options table; expanded Key Remapping section with a Memory Management subsection; renamed "run log" → "process log" throughout; updated filename pattern from `*_run.jsonl` → `*_process.jsonl`; added per-channel `delivers_audit` / `delivers_process_log` config key documentation with a channel-type defaults table
- **`audit-channel.md`**: Renamed "run log" → "process log" throughout; updated interactive flow step 5 and option descriptions; renamed the `audit:list` "Run Log" column to "Process Log"; added a new "What each channel delivers" section with a defaults table and `clonio.json` override example
- **`cloning-column-edit.md`**: Documented the faker argument hints shown after method selection (both interactive and `--faker-method` flag paths); added argument reference table for all methods that accept parameters

## Test plan

- [ ] Review `docs/commands/cloning-run.md` — flags, memory management section, process log naming
- [ ] Review `docs/commands/audit-channel.md` — process log naming, delivery defaults table, clonio.json example
- [ ] Review `docs/commands/cloning-column-edit.md` — faker argument hints section and reference table

🤖 Generated with [Claude Code](https://claude.com/claude-code)