### PR TITLE
feat: auto-append .env and clonio.json to .gitignore on init

### DIFF
--- a/app/Commands/InitCommand.php
+++ b/app/Commands/InitCommand.php
@@ -39,6 +39,7 @@ class InitCommand extends Command
                 $this->info('  ✓  APP_KEY found in .env — ready.');
             }
 
+            $this->ensureGitignoreEntries();
             $this->ensureDefaultAuditChannels($config);
 
             return ExitCode::Success->value;
@@ -56,6 +57,7 @@ class InitCommand extends Command
                 $this->line('  Cancelled.');
                 $this->line('');
 
+                $this->ensureGitignoreEntries();
                 $this->ensureDefaultAuditChannels($config);
 
                 return ExitCode::Success->value;
@@ -84,8 +86,7 @@ class InitCommand extends Command
         $this->info(sprintf('  ✓  Created .env with APP_KEY in %s', $cwdDisplay));
         $this->line('');
 
-        $this->showGitignoreHint();
-
+        $this->ensureGitignoreEntries();
         $this->ensureDefaultAuditChannels($config);
 
         return ExitCode::Success->value;
@@ -192,9 +193,14 @@ class InitCommand extends Command
         chmod(Storage::path('.env'), 0600);
     }
 
-    private function showGitignoreHint(): void
+    private function ensureGitignoreEntries(): void
     {
+        $entries = ['.env', 'clonio.json'];
+
         if (! Storage::exists('.gitignore')) {
+            $this->line('  ℹ  No .gitignore found. Add .env and clonio.json to avoid committing secrets.');
+            $this->line('');
+
             return;
         }
 
@@ -204,11 +210,16 @@ class InitCommand extends Command
             return;
         }
 
-        if (preg_match('/^\.env$/m', $content)) {
-            return;
-        }
+        foreach ($entries as $entry) {
+            $escaped = preg_quote($entry, '/');
 
-        $this->line('  ℹ  Remember to add .env to your .gitignore to avoid committing your APP_KEY.');
-        $this->line('');
+            if (preg_match('/^\\/?'.$escaped.'\\s*$/m', $content)) {
+                continue;
+            }
+
+            $content = rtrim($content)."\n".$entry."\n";
+            Storage::put('.gitignore', $content);
+            $this->info(sprintf('  ✓  Added to .gitignore: %s', $entry));
+        }
     }
 }

--- a/tests/Feature/Commands/InitCommandTest.php
+++ b/tests/Feature/Commands/InitCommandTest.php
@@ -63,25 +63,63 @@ it('appends APP_KEY to existing .env that has no key', function (): void {
         ->toContain('APP_KEY=base64:');
 });
 
-it('shows gitignore hint when .gitignore exists without .env entry', function (): void {
+it('auto-appends .env and clonio.json to .gitignore when both are missing', function (): void {
     putenv('APP_KEY');
     unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
 
     Storage::put('.gitignore', "/vendor\n/builds\n");
 
     $this->artisan('init')
-        ->expectsOutputToContain('Remember to add .env to your .gitignore')
+        ->expectsOutputToContain('Added to .gitignore: .env')
+        ->expectsOutputToContain('Added to .gitignore: clonio.json')
         ->assertExitCode(0);
+
+    $content = Storage::get('.gitignore');
+    expect($content)->toContain('.env')->toContain('clonio.json');
 });
 
-it('does not show gitignore hint when .env is already in .gitignore', function (): void {
+it('only appends clonio.json when .env is already in .gitignore', function (): void {
     putenv('APP_KEY');
     unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
 
     Storage::put('.gitignore', "/vendor\n.env\n");
 
     $this->artisan('init')
-        ->doesntExpectOutputToContain('Remember to add .env')
+        ->doesntExpectOutputToContain('Added to .gitignore: .env')
+        ->expectsOutputToContain('Added to .gitignore: clonio.json')
+        ->assertExitCode(0);
+
+    $content = Storage::get('.gitignore');
+    expect($content)->toContain('clonio.json');
+});
+
+it('appends nothing when both .env and clonio.json are already in .gitignore', function (): void {
+    putenv('APP_KEY');
+    unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
+
+    Storage::put('.gitignore', "/vendor\n.env\nclonio.json\n");
+
+    $this->artisan('init')
+        ->doesntExpectOutputToContain('Added to .gitignore')
+        ->assertExitCode(0);
+});
+
+it('prints a note when no .gitignore exists', function (): void {
+    putenv('APP_KEY');
+    unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
+
+    $this->artisan('init')
+        ->expectsOutputToContain('No .gitignore found')
+        ->assertExitCode(0);
+});
+
+it('auto-appends to .gitignore even when APP_KEY already exists in environment', function (): void {
+    // APP_KEY already in env from beforeEach
+    Storage::put('.gitignore', "/vendor\n");
+
+    $this->artisan('init')
+        ->expectsOutputToContain('Added to .gitignore: .env')
+        ->expectsOutputToContain('Added to .gitignore: clonio.json')
         ->assertExitCode(0);
 });
 


### PR DESCRIPTION
Closes #48

## Summary

- Replaces `showGitignoreHint()` with `ensureGitignoreEntries()` in `InitCommand`
- When `.gitignore` exists: automatically appends missing `.env` and `clonio.json` entries and prints what was added
- When `.gitignore` does not exist: prints a note listing both files to add
- The check now runs on **all** successful `init` paths (key already in env, key in `.env`, force-regen cancelled, or new key generated) — previously it only ran when a new key was created

## Test plan

- [ ] `init` with no `.gitignore`: prints "No .gitignore found" note
- [ ] `init` with `.gitignore` missing both entries: appends both, prints confirmation for each
- [ ] `init` with `.gitignore` containing only `.env`: appends only `clonio.json`
- [ ] `init` with `.gitignore` containing both: no output, no change
- [ ] `init` when `APP_KEY` already in environment: still runs gitignore check

🤖 Generated with [Claude Code](https://claude.com/claude-code)