### PR TITLE
feat: ask for transfer options at dump time, allow overrides at run time

### DIFF
--- a/app/Commands/Cloning/DumpCommand.php
+++ b/app/Commands/Cloning/DumpCommand.php
@@ -30,13 +30,17 @@ class DumpCommand extends Command
      * @var string
      */
     protected $signature = 'cloning:dump
-        {--connection=  : Name of the saved connection to inspect}
-        {--output=      : Output file path (default: <connection-name>.cloning.yaml)}
-        {--force        : Overwrite an existing file without asking}
-        {--only-pii     : Omit tables/columns with no PII match}
-        {--all-columns  : Include all columns in the YAML, not just PII-detected ones}
-        {--locale=      : FakerPHP locale for options.faker_locale (default: en_US)}
-        {--ci           : CI mode — suppress non-error output}';
+        {--connection=           : Name of the saved connection to inspect}
+        {--output=               : Output file path (default: <connection-name>.cloning.yaml)}
+        {--force                 : Overwrite an existing file without asking}
+        {--only-pii              : Omit tables/columns with no PII match}
+        {--all-columns           : Include all columns in the YAML, not just PII-detected ones}
+        {--locale=               : FakerPHP locale for options.faker_locale (default: en_US)}
+        {--enforce-column-types  : Set enforce_column_types: true in the generated YAML}
+        {--drop-unknown-tables   : Set drop_unknown_tables: true in the generated YAML}
+        {--drop-extra-columns    : Set drop_extra_columns: true in the generated YAML}
+        {--no-disable-fk-checks  : Set disable_foreign_key_checks: false in the generated YAML}
+        {--ci                    : CI mode — suppress non-error output}';
 
     /**
      * @var string
@@ -235,7 +239,22 @@ class DumpCommand extends Command
             );
         }
 
-        // 10. Build result
+        // 10. Collect transfer options
+        $enforceColumnTypes = (bool) $this->option('enforce-column-types');
+        $dropUnknownTables = (bool) $this->option('drop-unknown-tables');
+        $dropExtraColumns = (bool) $this->option('drop-extra-columns');
+        $disableForeignKeyChecks = ! $this->option('no-disable-fk-checks');
+
+        if (! $ci) {
+            $this->line('  Transfer options:');
+            $enforceColumnTypes = $this->confirm('    Enforce column types on target?', $enforceColumnTypes);
+            $dropUnknownTables = $this->confirm('    Drop unknown tables on target?', $dropUnknownTables);
+            $dropExtraColumns = $this->confirm('    Drop extra columns on target?', $dropExtraColumns);
+            $disableForeignKeyChecks = $this->confirm('    Disable foreign key checks?', $disableForeignKeyChecks);
+            $this->line('');
+        }
+
+        // 11. Build result
         $result = new DumpResultData(
             connectionName: $connectionName,
             tables: $tableDumps,
@@ -245,12 +264,16 @@ class DumpCommand extends Command
             fakerLocale: $fakerLocale,
             keyRemapping: $onlyPii ? null : $this->buildKeyRemapping($schema),
             includeKeepColumns: $allColumns,
+            enforceColumnTypes: $enforceColumnTypes,
+            dropUnknownTables: $dropUnknownTables,
+            dropExtraColumns: $dropExtraColumns,
+            disableForeignKeyChecks: $disableForeignKeyChecks,
         );
 
-        // 11. Write YAML
+        // 12. Write YAML
         $yamlWriter->writeToFile($result, $outputPath);
 
-        // 12. Print summary
+        // 13. Print summary
         if (! $ci) {
             $keepColumns = $totalColumns - $piiColumnsDetected;
 

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Commands\Cloning;
 
 use App\Data\Cloning\CloningConfigData;
+use App\Data\Cloning\CloningOptionsData;
 use App\Data\Cloning\ColumnCloningConfigData;
 use App\Data\Cloning\DryRunResultData;
 use App\Data\Cloning\DryRunTableData;
@@ -56,9 +57,17 @@ class RunCommand extends Command
         {--skip-tables=        : Comma-separated list of table names to exclude}
         {--only-tables=        : Comma-separated list of table names to include}
         {--audit-channel=      : Comma-separated list of channel names}
-        {--skip-remapping-keys : Skip key mapping generation and FK rewriting}
-        {--no-memory-limit     : Remove PHP memory limit before generating key mappings (useful for very large databases when --file-based is not an option)}
-        {--file-based          : Store key mappings in AES-256-CBC encrypted temp files instead of RAM; keeps memory usage bounded to the largest single table}';
+        {--skip-remapping-keys      : Skip key mapping generation and FK rewriting}
+        {--no-memory-limit          : Remove PHP memory limit before generating key mappings (useful for very large databases when --file-based is not an option)}
+        {--file-based               : Store key mappings in AES-256-CBC encrypted temp files instead of RAM; keeps memory usage bounded to the largest single table}
+        {--enforce-column-types     : Override: enforce_column_types true for this run}
+        {--no-enforce-column-types  : Override: enforce_column_types false for this run}
+        {--drop-unknown-tables      : Override: drop_unknown_tables true for this run}
+        {--no-drop-unknown-tables   : Override: drop_unknown_tables false for this run}
+        {--drop-extra-columns       : Override: drop_extra_columns true for this run}
+        {--no-drop-extra-columns    : Override: drop_extra_columns false for this run}
+        {--disable-fk-checks        : Override: disable_foreign_key_checks true for this run}
+        {--no-disable-fk-checks     : Override: disable_foreign_key_checks false for this run}';
 
     /**
      * @var string
@@ -152,6 +161,30 @@ class RunCommand extends Command
         $auditChannels = ($auditChannelOpt !== null && $auditChannelOpt !== '')
             ? array_values(array_filter(array_map(trim(...), explode(',', (string) $auditChannelOpt))))
             : [];
+
+        // ─── Option overrides ──────────────────────────────────────────────────
+        $enforceOverride = $this->option('enforce-column-types') ? true : ($this->option('no-enforce-column-types') ? false : null);
+        $dropUnkOverride = $this->option('drop-unknown-tables') ? true : ($this->option('no-drop-unknown-tables') ? false : null);
+        $dropExtOverride = $this->option('drop-extra-columns') ? true : ($this->option('no-drop-extra-columns') ? false : null);
+        $fkChecksOverride = $this->option('no-disable-fk-checks') ? false : ($this->option('disable-fk-checks') ? true : null);
+
+        if ($enforceOverride !== null || $dropUnkOverride !== null || $dropExtOverride !== null || $fkChecksOverride !== null) {
+            $opts = $config->options;
+            $config = new CloningConfigData(
+                version: $config->version,
+                connectionName: $config->connectionName,
+                options: new CloningOptionsData(
+                    chunkSize: $opts->chunkSize,
+                    enforceColumnTypes: $enforceOverride ?? $opts->enforceColumnTypes,
+                    dropUnknownTables: $dropUnkOverride ?? $opts->dropUnknownTables,
+                    dropExtraColumns: $dropExtOverride ?? $opts->dropExtraColumns,
+                    disableForeignKeyChecks: $fkChecksOverride ?? $opts->disableForeignKeyChecks,
+                    fakerLocale: $opts->fakerLocale,
+                ),
+                tables: $config->tables,
+                keyRemapping: $config->keyRemapping,
+            );
+        }
 
         // ─── Phase 2: Connection Checks ────────────────────────────────────────
 

--- a/app/Data/Cloning/DumpResultData.php
+++ b/app/Data/Cloning/DumpResultData.php
@@ -16,5 +16,9 @@ final readonly class DumpResultData
         public string $fakerLocale = 'en_US',
         public ?KeyRemappingConfigData $keyRemapping = null,
         public bool $includeKeepColumns = false,
+        public bool $enforceColumnTypes = false,
+        public bool $dropUnknownTables = false,
+        public bool $dropExtraColumns = false,
+        public bool $disableForeignKeyChecks = true,
     ) {}
 }

--- a/app/Services/Cloning/CloningYamlWriter.php
+++ b/app/Services/Cloning/CloningYamlWriter.php
@@ -23,10 +23,10 @@ class CloningYamlWriter
         $lines[] = '';
         $lines[] = 'options:';
         $lines[] = '  chunk_size: 1000';
-        $lines[] = '  enforce_column_types: false';
-        $lines[] = '  drop_unknown_tables: false';
-        $lines[] = '  drop_extra_columns: false';
-        $lines[] = '  disable_foreign_key_checks: true';
+        $lines[] = sprintf('  enforce_column_types: %s', $result->enforceColumnTypes ? 'true' : 'false');
+        $lines[] = sprintf('  drop_unknown_tables: %s', $result->dropUnknownTables ? 'true' : 'false');
+        $lines[] = sprintf('  drop_extra_columns: %s', $result->dropExtraColumns ? 'true' : 'false');
+        $lines[] = sprintf('  disable_foreign_key_checks: %s', $result->disableForeignKeyChecks ? 'true' : 'false');
         $lines[] = sprintf('  faker_locale: %s', $result->fakerLocale);
         $lines[] = '';
         $lines[] = 'tables:';

--- a/tests/Feature/Commands/Cloning/DumpCommandTest.php
+++ b/tests/Feature/Commands/Cloning/DumpCommandTest.php
@@ -540,3 +540,106 @@ it('only-pii: only includes PII columns and tables', function (): void {
     expect($yaml)->toContain('email:');
     expect($yaml)->not->toContain('id:');
 });
+
+it('writes enforce_column_types: true when --enforce-column-types flag is set', function (): void {
+    Storage::fake('local');
+
+    $connection = makeDumpMysqlConnection('production-db');
+    $schema = makeSimpleSchema();
+    $piiSet = makePiiMatcherSet();
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('exists')->andReturn(true);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn($connection);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($schema);
+
+    $piiLoader = Mockery::mock(PiiMatcherLoader::class);
+    $piiLoader->shouldReceive('load')->andReturn($piiSet);
+
+    $this->app->instance(ConfigService::class, $config);
+    $this->app->instance(SchemaInspector::class, $inspector);
+    $this->app->instance(PiiMatcherLoader::class, $piiLoader);
+
+    $this->artisan('cloning:dump', [
+        '--connection' => 'production-db',
+        '--enforce-column-types' => true,
+        '--drop-unknown-tables' => true,
+        '--drop-extra-columns' => true,
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+
+    $yaml = Storage::disk('local')->get('production-db.cloning.yaml');
+    expect($yaml)
+        ->toContain('enforce_column_types: true')
+        ->toContain('drop_unknown_tables: true')
+        ->toContain('drop_extra_columns: true')
+        ->toContain('disable_foreign_key_checks: true');
+});
+
+it('writes disable_foreign_key_checks: false when --no-disable-fk-checks flag is set', function (): void {
+    Storage::fake('local');
+
+    $connection = makeDumpMysqlConnection('production-db');
+    $schema = makeSimpleSchema();
+    $piiSet = makePiiMatcherSet();
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('exists')->andReturn(true);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn($connection);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($schema);
+
+    $piiLoader = Mockery::mock(PiiMatcherLoader::class);
+    $piiLoader->shouldReceive('load')->andReturn($piiSet);
+
+    $this->app->instance(ConfigService::class, $config);
+    $this->app->instance(SchemaInspector::class, $inspector);
+    $this->app->instance(PiiMatcherLoader::class, $piiLoader);
+
+    $this->artisan('cloning:dump', [
+        '--connection' => 'production-db',
+        '--no-disable-fk-checks' => true,
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+
+    $yaml = Storage::disk('local')->get('production-db.cloning.yaml');
+    expect($yaml)->toContain('disable_foreign_key_checks: false');
+});
+
+it('prompts for transfer options interactively and writes the chosen values', function (): void {
+    Storage::fake('local');
+
+    $connection = makeDumpMysqlConnection('production-db');
+    $schema = makeSimpleSchema();
+    $piiSet = makePiiMatcherSet();
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('exists')->andReturn(true);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn($connection);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($schema);
+
+    $piiLoader = Mockery::mock(PiiMatcherLoader::class);
+    $piiLoader->shouldReceive('load')->andReturn($piiSet);
+
+    $this->app->instance(ConfigService::class, $config);
+    $this->app->instance(SchemaInspector::class, $inspector);
+    $this->app->instance(PiiMatcherLoader::class, $piiLoader);
+
+    $this->artisan('cloning:dump', ['--connection' => 'production-db'])
+        ->expectsConfirmation('    Enforce column types on target?', 'yes')
+        ->expectsConfirmation('    Drop unknown tables on target?', 'no')
+        ->expectsConfirmation('    Drop extra columns on target?', 'no')
+        ->expectsConfirmation('    Disable foreign key checks?', 'yes')
+        ->assertExitCode(ExitCode::Success->value);
+
+    $yaml = Storage::disk('local')->get('production-db.cloning.yaml');
+    expect($yaml)
+        ->toContain('enforce_column_types: true')
+        ->toContain('drop_unknown_tables: false')
+        ->toContain('disable_foreign_key_checks: true');
+});

--- a/tests/Feature/Commands/Cloning/RunCommandTest.php
+++ b/tests/Feature/Commands/Cloning/RunCommandTest.php
@@ -873,3 +873,61 @@ YAML;
         ->expectsOutputToContain('target matches source')
         ->assertExitCode(ExitCode::Success->value);
 });
+
+it('applies --enforce-column-types override from CLI flags', function (): void {
+    Storage::fake('local');
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $config->shouldReceive('load')->andReturn(['connections' => []]);
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn(makeRunSimpleSchema());
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    $capturedConfig = null;
+    $orchestrator = Mockery::mock(CloningRunOrchestrator::class);
+    $orchestrator->shouldReceive('run')
+        ->withArgs(function (CloningConfigData $cfg) use (&$capturedConfig): bool {
+            $capturedConfig = $cfg;
+
+            return true;
+        })
+        ->andReturn(makeRunResult());
+    $this->app->instance(CloningRunOrchestrator::class, $orchestrator);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--enforce-column-types' => true,
+        '--no-disable-fk-checks' => true,
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+
+    expect($capturedConfig)->not->toBeNull();
+    expect($capturedConfig->options->enforceColumnTypes)->toBeTrue();
+    expect($capturedConfig->options->disableForeignKeyChecks)->toBeFalse();
+    // Unchanged from YAML
+    expect($capturedConfig->options->dropUnknownTables)->toBeFalse();
+});

--- a/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
@@ -119,6 +119,29 @@ it('writes options block with all required fields', function (): void {
     expect($yaml)->toContain('faker_locale: en_US');
 });
 
+it('writes non-default options when overridden in DumpResultData', function (): void {
+    $writer = new CloningYamlWriter;
+    $result = new DumpResultData(
+        connectionName: 'prod',
+        tables: [],
+        totalColumns: 0,
+        piiColumnsDetected: 0,
+        outputPath: 'prod.cloning.yaml',
+        enforceColumnTypes: true,
+        dropUnknownTables: true,
+        dropExtraColumns: true,
+        disableForeignKeyChecks: false,
+    );
+
+    $yaml = $writer->write($result);
+
+    expect($yaml)
+        ->toContain('enforce_column_types: true')
+        ->toContain('drop_unknown_tables: true')
+        ->toContain('drop_extra_columns: true')
+        ->toContain('disable_foreign_key_checks: false');
+});
+
 it('writes fake strategy column with faker_method and arguments', function (): void {
     $writer = new CloningYamlWriter;
     $table = new TableDumpData(


### PR DESCRIPTION
Closes #51

## Summary

- **`cloning:dump`** now prompts interactively for the 4 schema-transfer boolean options after schema inspection (skipped in `--ci` mode). Four new flags allow setting them non-interactively: `--enforce-column-types`, `--drop-unknown-tables`, `--drop-extra-columns`, `--no-disable-fk-checks`. Values are written to the `options:` block in the generated YAML instead of being hardcoded.
- **`cloning:run`** gains 8 new override flags (`--enforce-column-types` / `--no-enforce-column-types`, `--drop-unknown-tables` / `--no-drop-unknown-tables`, `--drop-extra-columns` / `--no-drop-extra-columns`, `--disable-fk-checks` / `--no-disable-fk-checks`) applied after loading the YAML, so any run-time value overrides the stored config.
- **`DumpResultData`** extended with 4 new bool fields (all defaulting to existing behaviour).
- **`CloningYamlWriter`** uses the result fields instead of hardcoded strings.

## Test plan

- [ ] `cloning:dump --ci` with `--enforce-column-types` → YAML contains `enforce_column_types: true`
- [ ] `cloning:dump --ci` with `--no-disable-fk-checks` → YAML contains `disable_foreign_key_checks: false`
- [ ] `cloning:dump` (interactive) responds to prompts and writes chosen values
- [ ] `cloning:run` with `--enforce-column-types --no-disable-fk-checks` overrides YAML values
- [ ] `cloning:run` without override flags uses YAML values unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)