### PR TITLE
docs: update init, cloning:dump, and cloning:run for #48 and #51

### DIFF
--- a/docs/commands/cloning-dump.md
+++ b/docs/commands/cloning-dump.md
@@ -16,7 +16,12 @@ clonio cloning:dump [options]
 | `--output=<path>` | Output file path (default: `<connection-name>.cloning.yaml`) |
 | `--force` | Overwrite an existing file without asking |
 | `--only-pii` | Omit tables and columns with no PII match |
+| `--all-columns` | Include all columns in the YAML, not just PII-detected ones |
 | `--locale=<locale>` | FakerPHP locale for `options.faker_locale` (default: `en_US`) |
+| `--enforce-column-types` | Set `enforce_column_types: true` in the generated YAML |
+| `--drop-unknown-tables` | Set `drop_unknown_tables: true` in the generated YAML |
+| `--drop-extra-columns` | Set `drop_extra_columns: true` in the generated YAML |
+| `--no-disable-fk-checks` | Set `disable_foreign_key_checks: false` in the generated YAML |
 | `--ci` | CI mode — suppress non-error output and require `--connection` |
 
 ## Description
@@ -67,6 +72,12 @@ clonio cloning:dump
 
   Schema fetched: 24 tables, 187 columns
 
+  Transfer options:
+    Enforce column types on target? (no)
+    Drop unknown tables on target? (no)
+    Drop extra columns on target? (no)
+    Disable foreign key checks? (yes)
+
   PII auto-detection:
     ✓  12 columns matched across 5 tables
     ○  175 columns set to keep
@@ -96,6 +107,27 @@ Use `--only-pii` to generate a minimal config that only lists tables and columns
 ```bash
 clonio cloning:dump --connection production-db --only-pii
 ```
+
+### Setting transfer options at dump time
+
+After inspecting the schema, Clonio prompts for four schema-transfer options that control how `cloning:run` synchronizes the target schema. In interactive mode you answer yes/no at the prompt; defaults match the recommended safe settings:
+
+| Prompt | Flag | Default | Effect on target |
+|--------|------|---------|-----------------|
+| Enforce column types on target? | `--enforce-column-types` | `false` | Add columns to existing tables that are present in the source but missing from the target |
+| Drop unknown tables on target? | `--drop-unknown-tables` | `false` | Drop tables from the target that do not exist in the source |
+| Drop extra columns on target? | `--drop-extra-columns` | `false` | Drop columns from existing target tables that are absent from the source |
+| Disable foreign key checks? | `--no-disable-fk-checks` to disable | `true` | Disable FK constraint checks during data transfer |
+
+In `--ci` mode the prompts are skipped and only the flags apply:
+
+```bash
+clonio cloning:dump --connection production-db --ci \
+  --enforce-column-types \
+  --drop-unknown-tables
+```
+
+The chosen values are written directly into the `options:` block of the generated YAML and serve as the baseline for every `cloning:run` against that file. Individual run-time overrides are available via `cloning:run` flags (see [cloning:run — Schema Synchronization](cloning-run.md#schema-synchronization)).
 
 ### CI mode
 

--- a/docs/commands/cloning-run.md
+++ b/docs/commands/cloning-run.md
@@ -29,6 +29,14 @@ clonio cloning:run <file> [options]
 | `--skip-remapping-keys` | Skip key mapping generation and FK rewriting |
 | `--no-memory-limit` | Remove PHP's memory limit before generating key mappings. Useful for very large databases when `--file-based` is not viable. |
 | `--file-based` | Store key mappings in AES-256-CBC encrypted temporary files instead of RAM. Keeps memory usage bounded to the size of the largest single table's mapping. |
+| `--enforce-column-types` | Override: set `enforce_column_types: true` for this run |
+| `--no-enforce-column-types` | Override: set `enforce_column_types: false` for this run |
+| `--drop-unknown-tables` | Override: set `drop_unknown_tables: true` for this run |
+| `--no-drop-unknown-tables` | Override: set `drop_unknown_tables: false` for this run |
+| `--drop-extra-columns` | Override: set `drop_extra_columns: true` for this run |
+| `--no-drop-extra-columns` | Override: set `drop_extra_columns: false` for this run |
+| `--disable-fk-checks` | Override: set `disable_foreign_key_checks: true` for this run |
+| `--no-disable-fk-checks` | Override: set `disable_foreign_key_checks: false` for this run |
 
 `--skip-tables` and `--only-tables` are mutually exclusive. Verbosity flags `-v` / `-vv` / `-vvv` are also supported (see [Output Modes](#output-modes)).
 
@@ -109,13 +117,14 @@ clonio cloning:run production-db.cloning.yaml --target staging --ci
 
 ## Schema Synchronization
 
-Before transferring data, Clonio can synchronize the target schema to match the source. Three options in the `options:` block of the YAML file control this behaviour:
+Before transferring data, Clonio synchronizes the target schema to match the source. Four options in the `options:` block of the YAML file control this behaviour. These values are set interactively by `cloning:dump` and can be overridden at run time via CLI flags.
 
-| Option | Default | Effect |
-|--------|---------|--------|
-| `enforce_column_types` | `false` | Add columns to existing target tables that are present in the source but missing from the target |
-| `drop_extra_columns` | `false` | Drop columns from existing target tables that exist in the target but not in the source |
-| `drop_unknown_tables` | `false` | Drop tables from the target that do not exist in the source |
+| YAML option | Default | CLI override (on / off) | Effect |
+|-------------|---------|------------------------|--------|
+| `enforce_column_types` | `false` | `--enforce-column-types` / `--no-enforce-column-types` | Add columns to existing target tables that are present in the source but missing from the target |
+| `drop_unknown_tables` | `false` | `--drop-unknown-tables` / `--no-drop-unknown-tables` | Drop tables from the target that do not exist in the source |
+| `drop_extra_columns` | `false` | `--drop-extra-columns` / `--no-drop-extra-columns` | Drop columns from existing target tables that are absent from the source |
+| `disable_foreign_key_checks` | `true` | `--disable-fk-checks` / `--no-disable-fk-checks` | Disable FK constraint checks during data transfer |
 
 ```yaml
 options:
@@ -127,16 +136,37 @@ options:
   faker_locale: en_US
 ```
 
-All three options are applied during **Phase 4 — Schema Replication**, which runs before any data is transferred. Schema replication is skipped entirely when `--skip-schema` is passed on the command line.
+All schema-sync options are applied during **Phase 4 — Schema Replication**, which runs before any data is transferred. Schema replication is skipped entirely when `--skip-schema` is passed on the command line.
 
-### Behaviour matrix
+### Table creation
 
-| Source table | Target table | Action |
+**Missing tables are always created**, regardless of any option setting. If a table exists in the source but not on the target, Clonio creates it during Phase 4. No option needs to be enabled for this — it is unconditional.
+
+The following options control what happens to columns and tables that diverge from the source:
+
+| Source table | Target table | What triggers the action |
 |---|---|---|
-| Exists | Missing | Always created (regardless of `enforce_column_types`) |
+| Exists | **Missing** | **Always created** — no option required |
 | Exists | Exists, missing columns | Columns added when `enforce_column_types: true` |
 | Exists | Exists, extra columns | Columns dropped when `drop_extra_columns: true` |
 | Missing | Exists | Table dropped when `drop_unknown_tables: true` |
+
+### Overriding options at run time
+
+CLI flags override the YAML `options:` values for a single run without modifying the file:
+
+```bash
+# Force table-creation safety net even if YAML says false
+clonio cloning:run prod.cloning.yaml --target staging --enforce-column-types
+
+# Tear down stale tables on a throwaway CI database
+clonio cloning:run prod.cloning.yaml --target ci-db --drop-unknown-tables --drop-extra-columns
+
+# Disable a destructive option set in the YAML for this run only
+clonio cloning:run prod.cloning.yaml --target staging --no-drop-unknown-tables
+```
+
+Both the `--<option>` and `--no-<option>` variants are always available, so you can force either direction regardless of what the YAML contains.
 
 ### Schema diff in dry-run
 
@@ -305,12 +335,14 @@ Only runs when `--dry-run` is set. Fetches both the source and target schemas, c
 
 ### Phase 4 — Schema Replication
 
-Synchronizes the target schema with the source. Controlled by three options in the YAML `options` block (see [Schema Synchronization](#schema-synchronization)):
+Synchronizes the target schema with the source. Controlled by four options in the YAML `options` block (see [Schema Synchronization](#schema-synchronization)):
 
-- Always creates tables that exist in the source but not in the target.
+- **Always** creates tables that exist in the source but not in the target.
 - `enforce_column_types: true` — adds missing columns to existing target tables.
 - `drop_extra_columns: true` — drops columns from existing target tables that are absent in the source.
 - `drop_unknown_tables: true` — drops tables from the target that are not present in the source.
+
+Each option can be overridden for a single run via CLI flags (`--enforce-column-types`, `--drop-unknown-tables`, `--drop-extra-columns`, `--disable-fk-checks` and their `--no-*` counterparts) without modifying the YAML file.
 
 Skipped entirely when `--skip-schema` is set.
 

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -85,15 +85,26 @@ Defaults to `no`. If confirmed, the `.env` file is updated with the new key.
 | `.env` exists, no `APP_KEY` line     | Appends `APP_KEY=base64:...` without touching other entries |
 | `.env` exists with `APP_KEY`         | Does nothing (unless `--force` is passed)              |
 
-### `.gitignore` Hint
+### `.gitignore` Management
 
-After writing `.env`, if a `.gitignore` exists in the current directory but does not include `.env`, Clonio displays a reminder:
+After any successful initialisation, Clonio checks whether `.env` and `clonio.json` are protected by `.gitignore`. Both files contain secrets (the encryption key and encrypted database passwords) and must never be committed.
+
+**When `.gitignore` exists:** Clonio automatically appends any missing entries and reports what it added:
 
 ```
-  ℹ  Remember to add .env to your .gitignore to avoid committing your APP_KEY.
+  ✓  Added to .gitignore: clonio.json
+  ✓  Added to .gitignore: .env
 ```
 
-Clonio does **not** modify `.gitignore` automatically.
+If both entries are already present, nothing is printed and the file is not modified.
+
+**When no `.gitignore` exists:** Clonio prints a note without creating the file:
+
+```
+  ℹ  No .gitignore found. Add .env and clonio.json to avoid committing secrets.
+```
+
+This check runs on every `init` invocation — regardless of whether a key was newly generated or already present.
 
 ## Production Environments
 


### PR DESCRIPTION
## Summary

- **`init.md`** — replaces the old gitignore hint (print-only, .env only) with the new auto-append behaviour: Clonio now automatically adds both `.env` and `clonio.json` to `.gitignore` when missing, or prints a note when no `.gitignore` exists
- **`cloning-dump.md`** — adds the four new flags (`--enforce-column-types`, `--drop-unknown-tables`, `--drop-extra-columns`, `--no-disable-fk-checks`) and `--all-columns`; documents the interactive transfer options prompt; explains how chosen values flow into the generated YAML `options:` block; links to `cloning:run` for per-run overrides
- **`cloning-run.md`** — adds 8 schema-option override flags to the options table; expands Schema Synchronization with a dedicated "Table creation" subsection (tables are **always** created — no option required), an updated behaviour matrix, and override examples; updates Phase 4 description to mention the override flags

Closes documentation gap for clonio-dev/clonio-cli#48 and clonio-dev/clonio-cli#51.

## Test plan

- [ ] Read through each updated section for accuracy against the implementation in PRs #61 and #62
- [ ] Confirm flags table in `cloning-run.md` matches `RunCommand::$signature`
- [ ] Confirm flags table in `cloning-dump.md` matches `DumpCommand::$signature`

🤖 Generated with [Claude Code](https://claude.com/claude-code)