### PR TITLE
feat: schema replication robustness — FK regex fix, per-table fallback, AUTO_INCREMENT correction, --break-on-failure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 /storage/logs/*.log
 /clonio.json
 .DS_Store
+/.worktrees

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -67,7 +67,8 @@ class RunCommand extends Command
         {--drop-extra-columns       : Override: drop_extra_columns true for this run}
         {--no-drop-extra-columns    : Override: drop_extra_columns false for this run}
         {--disable-fk-checks        : Override: disable_foreign_key_checks true for this run}
-        {--no-disable-fk-checks     : Override: disable_foreign_key_checks false for this run}';
+        {--no-disable-fk-checks     : Override: disable_foreign_key_checks false for this run}
+        {--break-on-failure         : Abort the run immediately on the first table failure (schema or data)}';
 
     /**
      * @var string
@@ -352,6 +353,9 @@ class RunCommand extends Command
         /** @var list<string> $notFoundTables */
         $notFoundTables = [];
 
+        /** @var list<string> $schemaFailureTables */
+        $schemaFailureTables = [];
+
         $result = $orchestrator->run(
             config: $config,
             source: $sourceConnection,
@@ -360,7 +364,7 @@ class RunCommand extends Command
             skipSchema: $skipSchema,
             skipTables: $skipTables,
             onlyTables: $onlyTables,
-            onProgress: function (string $tableName, TableRunStatus $status, int $rows, int $skipped) use ($verbose, &$notFoundTables): void {
+            onProgress: function (string $tableName, TableRunStatus $status, int $rows, int $skipped) use ($verbose, &$notFoundTables, &$schemaFailureTables): void {
                 if ($verbose) {
                     if ($status === TableRunStatus::Transferred) {
                         $this->line(sprintf('  <info>✓</info>  %s  (%d rows)', $tableName, $rows));
@@ -369,6 +373,9 @@ class RunCommand extends Command
                         $notFoundTables[] = $tableName;
                     } elseif ($status === TableRunStatus::Failed) {
                         $this->line(sprintf('  <error>✗</error>  %s  — failed', $tableName));
+                    } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
+                        $this->line(sprintf('  <error>S</error>  %s  — schema replication failed, skipped', $tableName));
+                        $schemaFailureTables[] = $tableName;
                     }
                 } elseif ($status === TableRunStatus::Transferred) {
                     $indicator = $skipped > 0 ? 'F' : '.';
@@ -378,9 +385,13 @@ class RunCommand extends Command
                 } elseif ($status === TableRunStatus::NotFound) {
                     $this->output->write('?');
                     $notFoundTables[] = $tableName;
+                } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
+                    $this->output->write('S');
+                    $schemaFailureTables[] = $tableName;
                 }
             },
             keyRemapping: $keyRemappingService,
+            breakOnFailure: (bool) $this->option('break-on-failure'),
         );
 
         $finishedAt = new DateTimeImmutable('now', new DateTimeZone('UTC'));
@@ -488,6 +499,23 @@ class RunCommand extends Command
                 count($notFoundTables),
                 count($notFoundTables) === 1 ? '' : 's',
                 implode(', ', $notFoundTables),
+            ));
+        }
+
+        // Collect schema failure tables from result (merge with those caught in onProgress)
+        $schemaFailuresFromResult = array_values(array_map(
+            static fn (TableRunResultData $t): string => $t->tableName,
+            array_filter($result->tables, static fn (TableRunResultData $t): bool => $t->status === TableRunStatus::SkippedBySchemaFailure)
+        ));
+        $schemaFailureTables = array_values(array_unique(array_merge($schemaFailureTables, $schemaFailuresFromResult)));
+
+        if ($schemaFailureTables !== []) {
+            $this->line('');
+            $this->line(sprintf(
+                '  <error>Error: %d table%s skipped due to schema replication failure (%s)</error>',
+                count($schemaFailureTables),
+                count($schemaFailureTables) === 1 ? '' : 's',
+                implode(', ', $schemaFailureTables),
             ));
         }
 

--- a/app/Data/Cloning/TableRunStatus.php
+++ b/app/Data/Cloning/TableRunStatus.php
@@ -10,5 +10,6 @@ enum TableRunStatus: string
     case SkippedByFlag = 'skipped_by_flag';
     case SkippedByCascade = 'skipped_by_cascade';
     case NotFound = 'not_found';
+    case SkippedBySchemaFailure = 'skipped_by_schema_failure';
     case Failed = 'failed';
 }

--- a/app/Services/Cloning/CloningRunOrchestrator.php
+++ b/app/Services/Cloning/CloningRunOrchestrator.php
@@ -13,7 +13,9 @@ use App\Data\Cloning\TableCloningConfigData;
 use App\Data\Cloning\TableRunResultData;
 use App\Data\Cloning\TableRunStatus;
 use App\Data\ConnectionData;
+use App\Data\Schema\ColumnSchemaData;
 use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\TableSchemaData;
 use App\Enums\ClearMode;
 use App\Enums\DatabaseConnectionType;
 use App\Services\Database\DatabaseConnectionService;
@@ -43,6 +45,7 @@ class CloningRunOrchestrator
         array $onlyTables,
         callable $onProgress,
         ?KeyRemappingService $keyRemapping = null,
+        bool $breakOnFailure = false,
     ): RunResultData {
         $start = microtime(true);
         $tableNames = array_map(static fn (TableCloningConfigData $t): string => $t->tableName, $config->tables);
@@ -68,20 +71,26 @@ class CloningRunOrchestrator
         $sortedTables = $this->resolver->sort($sourceSchema, $remaining);
 
         // Replicate schema if not skipping
+        /** @var array<string, string> $schemaFailures */
+        $schemaFailures = [];
+
         if (! $skipSchema) {
-            try {
-                $this->replicator->replicate(
-                    $source,
-                    $target,
-                    $sourceSchema,
-                    $sortedTables,
-                    $config->options->enforceColumnTypes,
-                    $config->options->dropUnknownTables,
-                    $config->options->dropExtraColumns,
-                );
+            $schemaFailures = $this->replicator->replicate(
+                $source,
+                $target,
+                $sourceSchema,
+                $sortedTables,
+                $config->options->enforceColumnTypes,
+                $config->options->dropUnknownTables,
+                $config->options->dropExtraColumns,
+            );
+
+            if ($schemaFailures === []) {
                 $this->runLog->log('info', 'schema_replicated', ['tables' => $sortedTables]);
-            } catch (Throwable $e) {
-                $this->runLog->log('error', 'schema_replication_failed', ['error' => $e->getMessage()]);
+            } else {
+                foreach ($schemaFailures as $failedTable => $errorMsg) {
+                    $this->runLog->log('error', 'schema_table_failed', ['table' => $failedTable, 'error' => $errorMsg]);
+                }
             }
         }
 
@@ -111,6 +120,20 @@ class CloningRunOrchestrator
                 continue;
             }
 
+            // Skip data transfer for tables whose schema could not be created
+            if (array_key_exists($tableName, $schemaFailures)) {
+                $tableResults[] = new TableRunResultData($tableName, TableRunStatus::SkippedBySchemaFailure, 0, 0, 0.0, $schemaFailures[$tableName]);
+                $this->runLog->log('warning', 'table_skipped_schema_failure', ['table' => $tableName]);
+                $success = false;
+                ($onProgress)($tableName, TableRunStatus::SkippedBySchemaFailure, 0, 0);
+
+                if ($breakOnFailure) {
+                    break;
+                }
+
+                continue;
+            }
+
             // Check if table exists in source
             if (! $sourceSchema->hasTable($tableName)) {
                 $tableResults[] = new TableRunResultData($tableName, TableRunStatus::NotFound, 0, 0, 0.0, null);
@@ -137,6 +160,26 @@ class CloningRunOrchestrator
             $totalRows += $rows;
             $totalSkipped += $skipped;
             ($onProgress)($tableName, $status, $rows, $skipped);
+
+            if ($failed && $breakOnFailure) {
+                break;
+            }
+
+            if (! $failed) {
+                $sourceTable = $sourceSchema->getTable($tableName);
+
+                if ($sourceTable instanceof TableSchemaData) {
+                    $pkColumn = $this->findIntegerPkColumn($target, $sourceTable);
+
+                    if ($pkColumn !== null) {
+                        try {
+                            $this->replicator->correctAutoIncrement($target, $tableName, $pkColumn);
+                        } catch (Throwable $e) {
+                            $this->runLog->log('warning', 'auto_increment_correction_failed', ['table' => $tableName, 'error' => $e->getMessage()]);
+                        }
+                    }
+                }
+            }
         }
 
         $duration = microtime(true) - $start;
@@ -149,6 +192,31 @@ class CloningRunOrchestrator
             durationSeconds: $duration,
             failureReason: $success ? null : 'One or more tables failed to transfer',
         );
+    }
+
+    /**
+     * Return the single integer PK column name, or null if AUTO_INCREMENT correction does not apply.
+     * Only applies to MySQL/MariaDB targets with a single-column integer PK.
+     */
+    private function findIntegerPkColumn(ConnectionData $target, TableSchemaData $table): ?string
+    {
+        if (! in_array($target->type, [DatabaseConnectionType::Mysql, DatabaseConnectionType::MariaDB], true)) {
+            return null;
+        }
+
+        $pkColumns = array_values(array_filter($table->columns, static fn (ColumnSchemaData $c): bool => $c->isPrimary));
+
+        if (count($pkColumns) !== 1) {
+            return null;
+        }
+
+        $intTypes = ['int', 'bigint', 'mediumint', 'smallint', 'tinyint', 'integer'];
+
+        if (! in_array(strtolower($pkColumns[0]->type), $intTypes, true)) {
+            return null;
+        }
+
+        return $pkColumns[0]->name;
     }
 
     /**

--- a/app/Services/Cloning/SchemaReplicator.php
+++ b/app/Services/Cloning/SchemaReplicator.php
@@ -326,7 +326,8 @@ class SchemaReplicator
             );
 
             $row = (array) ($rows[0] ?? new \stdClass);
-            $nextVal = max(1, (int) ($row['next_val'] ?? 1));
+            $rawVal = $row['next_val'] ?? 1;
+            $nextVal = max(1, is_numeric($rawVal) ? (int) $rawVal : 1);
 
             DB::connection($connName)->statement(
                 'ALTER TABLE '.$quotedTable.' AUTO_INCREMENT = '.$nextVal

--- a/app/Services/Cloning/SchemaReplicator.php
+++ b/app/Services/Cloning/SchemaReplicator.php
@@ -303,6 +303,40 @@ class SchemaReplicator
     }
 
     /**
+     * Set AUTO_INCREMENT on a MySQL/MariaDB table to MAX(pkColumn)+1.
+     * No-op for non-MySQL/MariaDB targets.
+     *
+     * @throws Throwable if the query or ALTER statement fails
+     */
+    public function correctAutoIncrement(ConnectionData $target, string $tableName, string $pkColumn): void
+    {
+        if (! in_array($target->type, [DatabaseConnectionType::Mysql, DatabaseConnectionType::MariaDB], true)) {
+            return;
+        }
+
+        $connName = $this->connector->open($target);
+
+        try {
+            $quotedTable = '`'.$tableName.'`';
+            $quotedCol = '`'.$pkColumn.'`';
+
+            /** @var list<object> $rows */
+            $rows = DB::connection($connName)->select(
+                'SELECT COALESCE(MAX('.$quotedCol.'), 0) + 1 AS next_val FROM '.$quotedTable
+            );
+
+            $row = (array) ($rows[0] ?? new \stdClass);
+            $nextVal = max(1, (int) ($row['next_val'] ?? 1));
+
+            DB::connection($connName)->statement(
+                'ALTER TABLE '.$quotedTable.' AUTO_INCREMENT = '.$nextVal
+            );
+        } finally {
+            DB::purge($connName);
+        }
+    }
+
+    /**
      * Fetch native CREATE TABLE DDL from source and adapt it for the target.
      * Only called when source and target are the same DB type.
      * FK constraints and AUTO_INCREMENT counters are stripped so the statement

--- a/app/Services/Cloning/SchemaReplicator.php
+++ b/app/Services/Cloning/SchemaReplicator.php
@@ -24,7 +24,8 @@ class SchemaReplicator
     /**
      * Replicate source schema tables to target.
      *
-     * @param  list<string>  $tables  table names to replicate
+     * @param  list<string>  $tables
+     * @return array<string, string>  Map of tableName => errorMessage for tables that could not be created
      */
     public function replicate(
         ConnectionData $source,
@@ -34,9 +35,12 @@ class SchemaReplicator
         bool $enforceColumnTypes,
         bool $dropUnknownTables,
         bool $dropExtraColumns = false,
-    ): void {
+    ): array {
         $targetConnName = $this->connector->open($target);
         $sameDbType = $source->type === $target->type;
+
+        /** @var array<string, string> $failedTables */
+        $failedTables = [];
 
         try {
             $targetSchema = $this->inspector->inspect($target);
@@ -51,15 +55,29 @@ class SchemaReplicator
                 $targetTable = $targetSchema->getTable($tableName);
 
                 if (! $targetTable instanceof TableSchemaData) {
-                    // For same DB type, fetch native DDL from source to preserve exact column types
+                    $created = false;
+
                     if ($sameDbType) {
                         $nativeSql = $this->fetchNativeCreateTableDdl($source, $tableName);
+
+                        if ($nativeSql !== null) {
+                            try {
+                                DB::connection($targetConnName)->statement($nativeSql);
+                                $created = true;
+                            } catch (Throwable) {
+                                // native DDL failed — fall through to inspector-based fallback
+                            }
+                        }
                     }
 
-                    $sql = $nativeSql ?? $this->buildCreateTableSql($tableName, $sourceTable->columns, $target->type);
-
-                    DB::connection($targetConnName)->statement($sql);
-                    unset($nativeSql);
+                    if (! $created) {
+                        try {
+                            $fallbackSql = $this->buildCreateTableSql($tableName, $sourceTable->columns, $target->type);
+                            DB::connection($targetConnName)->statement($fallbackSql);
+                        } catch (Throwable $e) {
+                            $failedTables[$tableName] = $e->getMessage();
+                        }
+                    }
                 } else {
                     $sourceColNames = array_map(static fn (ColumnSchemaData $c): string => $c->name, $sourceTable->columns);
                     $targetColNames = array_map(static fn (ColumnSchemaData $c): string => $c->name, $targetTable->columns);
@@ -99,6 +117,8 @@ class SchemaReplicator
         } finally {
             DB::purge($targetConnName);
         }
+
+        return $failedTables;
     }
 
     /**

--- a/app/Services/Cloning/SchemaReplicator.php
+++ b/app/Services/Cloning/SchemaReplicator.php
@@ -12,6 +12,7 @@ use App\Enums\DatabaseConnectionType;
 use App\Services\Database\DatabaseConnectionService;
 use App\Services\Schema\SchemaInspector;
 use Illuminate\Support\Facades\DB;
+use stdClass;
 use Throwable;
 
 class SchemaReplicator
@@ -25,7 +26,7 @@ class SchemaReplicator
      * Replicate source schema tables to target.
      *
      * @param  list<string>  $tables
-     * @return array<string, string>  Map of tableName => errorMessage for tables that could not be created
+     * @return array<string, string> Map of tableName => errorMessage for tables that could not be created
      */
     public function replicate(
         ConnectionData $source,
@@ -325,7 +326,7 @@ class SchemaReplicator
                 'SELECT COALESCE(MAX('.$quotedCol.'), 0) + 1 AS next_val FROM '.$quotedTable
             );
 
-            $row = (array) ($rows[0] ?? new \stdClass);
+            $row = (array) ($rows[0] ?? new stdClass);
             $rawVal = $row['next_val'] ?? 1;
             $nextVal = max(1, is_numeric($rawVal) ? (int) $rawVal : 1);
 

--- a/app/Services/Cloning/SchemaReplicator.php
+++ b/app/Services/Cloning/SchemaReplicator.php
@@ -331,8 +331,9 @@ class SchemaReplicator
      */
     private function sanitiseNativeDdl(string $ddl): string
     {
-        // Remove CONSTRAINT ... FOREIGN KEY lines (entire line, including REFERENCES clause)
-        $ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN\s+KEY.*$/im', '', $ddl) ?? $ddl;
+        // Remove CONSTRAINT ... FOREIGN KEY definitions (full definition including REFERENCES and ON clauses).
+        // MySQL SHOW CREATE TABLE outputs each FK on its own line, but we match broadly for safety.
+        $ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN\s+KEY\s*\([^)]+\)\s*REFERENCES\s+`[^`]+`\s*\([^)]+\)(?:\s+ON\s+(?:DELETE|UPDATE)\s+\w+(?:\s+\w+)?)*/i', '', $ddl) ?? $ddl;
 
         // Remove dangling commas before the closing parenthesis
         $ddl = preg_replace('/,(\s*\))/m', '$1', $ddl) ?? $ddl;

--- a/app/Services/Cloning/SchemaReplicator.php
+++ b/app/Services/Cloning/SchemaReplicator.php
@@ -389,7 +389,7 @@ class SchemaReplicator
     {
         // Remove CONSTRAINT ... FOREIGN KEY definitions (full definition including REFERENCES and ON clauses).
         // MySQL SHOW CREATE TABLE outputs each FK on its own line, but we match broadly for safety.
-        $ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN\s+KEY\s*\([^)]+\)\s*REFERENCES\s+`[^`]+`\s*\([^)]+\)(?:\s+ON\s+(?:DELETE|UPDATE)\s+\w+(?:\s+\w+)?)*/i', '', $ddl) ?? $ddl;
+        $ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN\s+KEY\s*\([^)]+\)\s*REFERENCES\s+`[^`]+`\s*\([^)]+\)(?:\s+ON\s+(?:DELETE|UPDATE)\s+\w+(?:\s+(?!ON\b)\w+)?)*/i', '', $ddl) ?? $ddl;
 
         // Remove dangling commas before the closing parenthesis
         $ddl = preg_replace('/,(\s*\))/m', '$1', $ddl) ?? $ddl;

--- a/app/Services/Cloning/SchemaReplicator.php
+++ b/app/Services/Cloning/SchemaReplicator.php
@@ -331,8 +331,8 @@ class SchemaReplicator
      */
     private function sanitiseNativeDdl(string $ddl): string
     {
-        // Remove CONSTRAINT ... FOREIGN KEY lines
-        $ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN KEY[^,)]+(?:REFERENCES[^,)]+)?/i', '', $ddl) ?? $ddl;
+        // Remove CONSTRAINT ... FOREIGN KEY lines (entire line, including REFERENCES clause)
+        $ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN\s+KEY.*$/im', '', $ddl) ?? $ddl;
 
         // Remove dangling commas before the closing parenthesis
         $ddl = preg_replace('/,(\s*\))/m', '$1', $ddl) ?? $ddl;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use LaravelZero\Framework\Application;
 
 return Application::configure(basePath: dirname(__DIR__))->create();

--- a/config/app.php
+++ b/config/app.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use App\Providers\AppServiceProvider;
 use Illuminate\Encryption\EncryptionServiceProvider;
 

--- a/config/commands.php
+++ b/config/commands.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Console\Scheduling\ScheduleFinishCommand;
 use Illuminate\Console\Scheduling\ScheduleListCommand;
 use Illuminate\Console\Scheduling\ScheduleRunCommand;

--- a/config/database.php
+++ b/config/database.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Illuminate\Support\Str;
 use Pdo\Mysql;
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Monolog\Handler\NullHandler;
 use Monolog\Handler\StreamHandler;
 use Monolog\Handler\SyslogUdpHandler;

--- a/docs/commands/cloning-run.md
+++ b/docs/commands/cloning-run.md
@@ -37,8 +37,22 @@ clonio cloning:run <file> [options]
 | `--no-drop-extra-columns` | Override: set `drop_extra_columns: false` for this run |
 | `--disable-fk-checks` | Override: set `disable_foreign_key_checks: true` for this run |
 | `--no-disable-fk-checks` | Override: set `disable_foreign_key_checks: false` for this run |
+| `--break-on-failure` | Abort the run immediately on the first table failure (schema or data) |
 
 `--skip-tables` and `--only-tables` are mutually exclusive. Verbosity flags `-v` / `-vv` / `-vvv` are also supported (see [Output Modes](#output-modes)).
+
+### `--break-on-failure`
+
+By default, Clonio continues processing all tables even when one fails — every table gets a chance to transfer and the full results are reported at the end. Pass `--break-on-failure` to abort the run immediately the first time a table fails (either at schema creation or at data transfer).
+
+| Scenario | Without flag | With `--break-on-failure` |
+|---|---|---|
+| Schema failure on table A | Continue, skip A's data | Abort run |
+| Data failure on table B | Continue | Abort run |
+| All tables OK | `success: true` | `success: true` |
+| Partial failure | `success: false`, full results | `success: false`, partial results |
+
+The audit log is always written, even on early abort.
 
 ## Prerequisites
 
@@ -408,6 +422,19 @@ When a table is excluded, all tables with a foreign key dependency on it — dir
 
 Cascaded tables appear in the audit log with status `skipped_by_cascade`.
 
+## Table Run Statuses
+
+Each table in a run is recorded with one of the following statuses in the audit and process logs:
+
+| Status | Meaning |
+|--------|---------|
+| `transferred` | Table was transferred successfully |
+| `skipped_by_flag` | Table was excluded via `--skip-tables` or `--only-tables` |
+| `skipped_by_cascade` | Table was excluded because it has a FK dependency on a skipped table |
+| `skipped_by_schema_failure` | Table's schema could not be created in the target database (native DDL and fallback both failed); the data transfer step was skipped. Overall `success` is `false`. |
+| `not_found` | Table is listed in the YAML but does not exist in the source database |
+| `failed` | Table transfer was attempted but encountered an unrecoverable error |
+
 ## Output Modes
 
 ### `--ci` (CI mode)
@@ -434,6 +461,7 @@ Dot-style progress per table, with a summary at the end:
 | `F` | Table had skipped or failed rows |
 | `E` | Table aborted with an unrecoverable error |
 | `?` | Table not found in source (skipped) |
+| `S` | Table was skipped because schema creation failed |
 
 ### `-v` (verbose)
 

--- a/docs/superpowers/plans/2026-04-13-schema-replication-robustness.md
+++ b/docs/superpowers/plans/2026-04-13-schema-replication-robustness.md
@@ -1,0 +1,1199 @@
+# Schema Replication Robustness Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make schema replication robust against FK-regex bugs, per-table failures, and AUTO_INCREMENT drift; add `--break-on-failure` flag to `cloning:run`.
+
+**Architecture:** Fix the buggy FK-stripping regex in `SchemaReplicator::sanitiseNativeDdl()`, add a per-table native-DDL → inspector-based fallback, surface failures as `array<string,string>` back to the orchestrator, add `AUTO_INCREMENT` correction after data transfer, add `TableRunStatus::SkippedBySchemaFailure`, and wire `--break-on-failure` through `RunCommand` → `CloningRunOrchestrator`.
+
+**Tech Stack:** PHP 8.3, Laravel Zero, PestPHP v4, Mockery
+
+---
+
+### Task 1: Fix `sanitiseNativeDdl()` regex and tighten the FK test
+
+**Files:**
+- Modify: `app/Services/Cloning/SchemaReplicator.php`
+- Modify: `tests/Unit/Services/Cloning/SchemaReplicatorTest.php`
+
+- [ ] **Step 1: Update the FK test to also assert no `REFERENCES` in output**
+
+In `tests/Unit/Services/Cloning/SchemaReplicatorTest.php`, find the test `it strips FOREIGN KEY constraints from native DDL` and change the final assertion from:
+
+```php
+expect($capturedSql)
+    ->not->toContain('FOREIGN KEY')
+    ->not->toContain('CONSTRAINT')
+    ->toContain('IF NOT EXISTS');
+```
+
+to:
+
+```php
+expect($capturedSql)
+    ->not->toContain('FOREIGN KEY')
+    ->not->toContain('CONSTRAINT')
+    ->not->toContain('REFERENCES')
+    ->toContain('IF NOT EXISTS');
+```
+
+- [ ] **Step 2: Run the test to confirm it now fails**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/SchemaReplicatorTest.php --filter="strips FOREIGN KEY"
+```
+
+Expected: **FAIL** — `capturedSql` contains `REFERENCES`
+
+- [ ] **Step 3: Fix the regex in `SchemaReplicator::sanitiseNativeDdl()`**
+
+In `app/Services/Cloning/SchemaReplicator.php`, find `sanitiseNativeDdl()` (around line 332) and replace the CONSTRAINT regex line:
+
+```php
+// Remove CONSTRAINT ... FOREIGN KEY lines
+$ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN KEY[^,)]+(?:REFERENCES[^,)]+)?/i', '', $ddl) ?? $ddl;
+```
+
+with:
+
+```php
+// Remove CONSTRAINT ... FOREIGN KEY lines (entire line, including REFERENCES clause)
+$ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN\s+KEY.*$/im', '', $ddl) ?? $ddl;
+```
+
+The `m` flag makes `$` match end-of-line; `.` without `s` flag doesn't match newlines — the entire FK line is removed.
+
+- [ ] **Step 4: Run all SchemaReplicator tests**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+```
+
+Expected: all **PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Services/Cloning/SchemaReplicator.php tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+git commit -m "fix: strip entire FOREIGN KEY line including REFERENCES clause in native DDL sanitiser"
+```
+
+---
+
+### Task 2: Change `replicate()` return type and add per-table fallback
+
+**Files:**
+- Modify: `app/Services/Cloning/SchemaReplicator.php`
+- Modify: `tests/Unit/Services/Cloning/SchemaReplicatorTest.php`
+- Modify: `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php` (mock return value)
+
+- [ ] **Step 1: Write failing tests for the fallback and failure-map behaviour**
+
+Add to `tests/Unit/Services/Cloning/SchemaReplicatorTest.php`:
+
+```php
+it('falls back to buildCreateTableSql when native DDL execution fails on target', function (): void {
+    $sourceConn = makeReplicatorMysqlConnection('source');
+    $targetConn = makeReplicatorMysqlConnection('target');
+    $sourceSchema = makeSimpleSourceSchema(); // has 'users' table
+
+    $emptyTargetSchema = new DatabaseSchemaData(databaseName: 'targetdb', tables: []);
+    $showRow = new stdClass;
+    $showRow->{'Create Table'} = "CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB";
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($emptyTargetSchema);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('source_conn', 'target_conn');
+
+    $fallbackCalled = false;
+
+    DB::shouldReceive('connection')->with('source_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([$showRow]);
+    DB::shouldReceive('purge')->with('source_conn')->andReturnNull();
+
+    // First statement call (native DDL) throws; second (fallback) succeeds
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('statement')
+        ->once()->andThrow(new RuntimeException('syntax error'));
+    DB::shouldReceive('statement')
+        ->once()->withArgs(static function (string $sql) use (&$fallbackCalled): bool {
+            if (str_contains($sql, 'CREATE TABLE IF NOT EXISTS') && str_contains($sql, 'INT')) {
+                $fallbackCalled = true;
+            }
+            return true;
+        })->andReturnTrue();
+    DB::shouldReceive('purge')->with('target_conn')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $failures = $replicator->replicate($sourceConn, $targetConn, $sourceSchema, ['users'], false, false);
+
+    expect($fallbackCalled)->toBeTrue();
+    expect($failures)->toBeEmpty();
+});
+
+it('returns table name in failure map when both native DDL and fallback fail', function (): void {
+    $sourceConn = makeReplicatorMysqlConnection('source');
+    $targetConn = makeReplicatorMysqlConnection('target');
+    $sourceSchema = makeSimpleSourceSchema();
+
+    $emptyTargetSchema = new DatabaseSchemaData(databaseName: 'targetdb', tables: []);
+    $showRow = new stdClass;
+    $showRow->{'Create Table'} = "CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB";
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($emptyTargetSchema);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('source_conn', 'target_conn');
+
+    DB::shouldReceive('connection')->with('source_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([$showRow]);
+    DB::shouldReceive('purge')->andReturnNull();
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    // Both native and fallback throw
+    DB::shouldReceive('statement')->andThrow(new RuntimeException('table engine not supported'));
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $failures = $replicator->replicate($sourceConn, $targetConn, $sourceSchema, ['users'], false, false);
+
+    expect($failures)->toHaveKey('users');
+    expect($failures['users'])->toContain('table engine not supported');
+});
+```
+
+- [ ] **Step 2: Run these two new tests to confirm they fail**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/SchemaReplicatorTest.php --filter="falls back|returns table name in failure"
+```
+
+Expected: **FAIL** (return type mismatch or wrong behaviour)
+
+- [ ] **Step 3: Rewrite `replicate()` with per-table fallback and `array<string,string>` return**
+
+In `app/Services/Cloning/SchemaReplicator.php`, change the method signature from:
+
+```php
+public function replicate(
+    ConnectionData $source,
+    ConnectionData $target,
+    DatabaseSchemaData $sourceSchema,
+    array $tables,
+    bool $enforceColumnTypes,
+    bool $dropUnknownTables,
+    bool $dropExtraColumns = false,
+): void {
+```
+
+to:
+
+```php
+/**
+ * Replicate source schema tables to target.
+ *
+ * @param  list<string>  $tables
+ * @return array<string, string>  Map of tableName => errorMessage for tables that could not be created
+ */
+public function replicate(
+    ConnectionData $source,
+    ConnectionData $target,
+    DatabaseSchemaData $sourceSchema,
+    array $tables,
+    bool $enforceColumnTypes,
+    bool $dropUnknownTables,
+    bool $dropExtraColumns = false,
+): array {
+```
+
+Replace the inner `foreach ($tables as $tableName)` block (the part that handles missing target tables) with:
+
+```php
+/** @var array<string, string> $failedTables */
+$failedTables = [];
+
+foreach ($tables as $tableName) {
+    $sourceTable = $sourceSchema->getTable($tableName);
+
+    if (! $sourceTable instanceof TableSchemaData) {
+        continue;
+    }
+
+    $targetTable = $targetSchema->getTable($tableName);
+
+    if (! $targetTable instanceof TableSchemaData) {
+        $created = false;
+
+        if ($sameDbType) {
+            $nativeSql = $this->fetchNativeCreateTableDdl($source, $tableName);
+
+            if ($nativeSql !== null) {
+                try {
+                    DB::connection($targetConnName)->statement($nativeSql);
+                    $created = true;
+                } catch (Throwable) {
+                    // native DDL failed — fall through to inspector-based fallback
+                }
+            }
+        }
+
+        if (! $created) {
+            try {
+                $fallbackSql = $this->buildCreateTableSql($tableName, $sourceTable->columns, $target->type);
+                DB::connection($targetConnName)->statement($fallbackSql);
+            } catch (Throwable $e) {
+                $failedTables[$tableName] = $e->getMessage();
+            }
+        }
+    } else {
+        $sourceColNames = array_map(static fn (ColumnSchemaData $c): string => $c->name, $sourceTable->columns);
+        $targetColNames = array_map(static fn (ColumnSchemaData $c): string => $c->name, $targetTable->columns);
+
+        if ($enforceColumnTypes) {
+            foreach ($sourceTable->columns as $col) {
+                if (! in_array($col->name, $targetColNames, true)) {
+                    $alterSql = $this->buildAddColumnSql($tableName, $col, $target->type);
+                    DB::connection($targetConnName)->statement($alterSql);
+                }
+            }
+        }
+
+        if ($dropExtraColumns) {
+            foreach ($targetTable->columns as $col) {
+                if (! in_array($col->name, $sourceColNames, true)) {
+                    $dropColSql = $this->buildDropColumnSql($tableName, $col->name, $target->type);
+                    DB::connection($targetConnName)->statement($dropColSql);
+                }
+            }
+        }
+    }
+}
+
+if ($dropUnknownTables) {
+    $sourceTableNames = array_map(static fn (TableSchemaData $t): string => $t->name, $sourceSchema->tables);
+
+    foreach ($targetSchema->tables as $targetTable) {
+        if (! in_array($targetTable->name, $sourceTableNames, true)) {
+            $dropSql = $this->buildDropTableSql($targetTable->name, $target->type);
+            DB::connection($targetConnName)->statement($dropSql);
+        }
+    }
+}
+
+return $failedTables;
+```
+
+Remove the old `unset($nativeSql)` line and old variable assignments.
+
+- [ ] **Step 4: Fix the `makeOrchestrator()` mock in the orchestrator test**
+
+In `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php`, find:
+
+```php
+$replicator->shouldReceive('replicate')->andReturnNull();
+```
+
+and change to:
+
+```php
+$replicator->shouldReceive('replicate')->andReturn([]);
+```
+
+- [ ] **Step 5: Run all SchemaReplicator and orchestrator tests**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/SchemaReplicatorTest.php tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+```
+
+Expected: all **PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/Cloning/SchemaReplicator.php tests/Unit/Services/Cloning/SchemaReplicatorTest.php tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+git commit -m "feat: per-table schema fallback in replicate() with array<string,string> return"
+```
+
+---
+
+### Task 3: Add `TableRunStatus::SkippedBySchemaFailure`
+
+**Files:**
+- Modify: `app/Data/Cloning/TableRunStatus.php`
+
+- [ ] **Step 1: Add the new case**
+
+In `app/Data/Cloning/TableRunStatus.php`, add after `NotFound`:
+
+```php
+enum TableRunStatus: string
+{
+    case Transferred = 'transferred';
+    case SkippedByFlag = 'skipped_by_flag';
+    case SkippedByCascade = 'skipped_by_cascade';
+    case NotFound = 'not_found';
+    case SkippedBySchemaFailure = 'skipped_by_schema_failure';
+    case Failed = 'failed';
+}
+```
+
+- [ ] **Step 2: Run the full suite to confirm no regressions**
+
+```bash
+./vendor/bin/pest tests/Unit/ tests/Feature/
+```
+
+Expected: all **PASS**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Data/Cloning/TableRunStatus.php
+git commit -m "feat: add SkippedBySchemaFailure to TableRunStatus"
+```
+
+---
+
+### Task 4: Add `correctAutoIncrement()` to `SchemaReplicator` and test it
+
+**Files:**
+- Modify: `app/Services/Cloning/SchemaReplicator.php`
+- Modify: `tests/Unit/Services/Cloning/SchemaReplicatorTest.php`
+
+- [ ] **Step 1: Write failing tests for `correctAutoIncrement()`**
+
+Add to `tests/Unit/Services/Cloning/SchemaReplicatorTest.php`:
+
+```php
+it('sets AUTO_INCREMENT to max pk plus one', function (): void {
+    $targetConn = makeReplicatorMysqlConnection('target');
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('target_conn');
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    $maxRow = new stdClass;
+    $maxRow->next_val = 51;
+
+    $alterCalled = false;
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('select')->with(Mockery::pattern('/COALESCE.*MAX/i'))->andReturn([$maxRow]);
+    DB::shouldReceive('statement')->withArgs(static function (string $sql) use (&$alterCalled): bool {
+        if (str_contains($sql, 'AUTO_INCREMENT = 51')) {
+            $alterCalled = true;
+        }
+        return true;
+    })->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $replicator->correctAutoIncrement($targetConn, 'users', 'id');
+
+    expect($alterCalled)->toBeTrue();
+});
+
+it('sets AUTO_INCREMENT to 1 when table is empty', function (): void {
+    $targetConn = makeReplicatorMysqlConnection('target');
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('target_conn');
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    $maxRow = new stdClass;
+    $maxRow->next_val = 1; // COALESCE(MAX(id),0)+1 = 1 when table empty
+
+    $capturedSql = null;
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([$maxRow]);
+    DB::shouldReceive('statement')->withArgs(static function (string $sql) use (&$capturedSql): bool {
+        $capturedSql = $sql;
+        return true;
+    })->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $replicator->correctAutoIncrement($targetConn, 'users', 'id');
+
+    expect($capturedSql)->toContain('AUTO_INCREMENT = 1');
+});
+
+it('throws when AUTO_INCREMENT correction fails', function (): void {
+    $targetConn = makeReplicatorMysqlConnection('target');
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('target_conn');
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andThrow(new RuntimeException('query failed'));
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+
+    expect(fn () => $replicator->correctAutoIncrement($targetConn, 'users', 'id'))
+        ->toThrow(RuntimeException::class, 'query failed');
+});
+
+it('returns early without connecting for non-mysql target', function (): void {
+    $targetConn = new ConnectionData(
+        name: 'target',
+        type: DatabaseConnectionType::PostgreSQL,
+        host: 'localhost',
+        port: 5432,
+        database: 'testdb',
+        schema: null,
+        username: 'root',
+        password: 'secret',
+        isProduction: false,
+    );
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->never();
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    DB::shouldReceive('connection')->never();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $replicator->correctAutoIncrement($targetConn, 'users', 'id'); // should not throw or connect
+});
+```
+
+- [ ] **Step 2: Run new tests to confirm they fail**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/SchemaReplicatorTest.php --filter="AUTO_INCREMENT|sets AUTO|throws when AUTO|returns early without"
+```
+
+Expected: **FAIL** (method does not exist)
+
+- [ ] **Step 3: Implement `correctAutoIncrement()` in `SchemaReplicator`**
+
+Add after `fetchNativeCreateTableDdl()` in `app/Services/Cloning/SchemaReplicator.php`:
+
+```php
+/**
+ * Set AUTO_INCREMENT on a MySQL/MariaDB table to MAX(pkColumn)+1.
+ * Only connects when target is MySQL or MariaDB; no-op otherwise.
+ *
+ * @throws Throwable if the query or ALTER fails
+ */
+public function correctAutoIncrement(ConnectionData $target, string $tableName, string $pkColumn): void
+{
+    if (! in_array($target->type, [DatabaseConnectionType::Mysql, DatabaseConnectionType::MariaDB], true)) {
+        return;
+    }
+
+    $connName = $this->connector->open($target);
+
+    try {
+        $quotedTable = '`'.$tableName.'`';
+        $quotedCol = '`'.$pkColumn.'`';
+
+        /** @var list<object> $rows */
+        $rows = DB::connection($connName)->select(
+            'SELECT COALESCE(MAX('.$quotedCol.'), 0) + 1 AS next_val FROM '.$quotedTable
+        );
+
+        $row = (array) ($rows[0] ?? new \stdClass);
+        $nextVal = max(1, (int) ($row['next_val'] ?? 1));
+
+        DB::connection($connName)->statement(
+            'ALTER TABLE '.$quotedTable.' AUTO_INCREMENT = '.$nextVal
+        );
+    } finally {
+        DB::purge($connName);
+    }
+}
+```
+
+- [ ] **Step 4: Run all SchemaReplicator tests**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+```
+
+Expected: all **PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Services/Cloning/SchemaReplicator.php tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+git commit -m "feat: add correctAutoIncrement() to SchemaReplicator"
+```
+
+---
+
+### Task 5: Update `CloningRunOrchestrator` — schema failures, break-on-failure, AUTO_INCREMENT
+
+**Files:**
+- Modify: `app/Services/Cloning/CloningRunOrchestrator.php`
+- Modify: `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php`
+
+- [ ] **Step 1: Write failing tests for the new orchestrator behaviour**
+
+Add to `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php`:
+
+```php
+function makeOrchestratorWithSchemaFailures(array $schemaFailures): CloningRunOrchestrator
+{
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturnUsing(static fn (ConnectionData $c): string => $c->name.'_conn');
+
+    $replicator = Mockery::mock(SchemaReplicator::class);
+    $replicator->shouldReceive('replicate')->andReturn($schemaFailures);
+    $replicator->shouldReceive('correctAutoIncrement')->andReturnNull();
+
+    $resolver = Mockery::mock(DependencyResolver::class);
+    $resolver->shouldReceive('computeCascadeExclusions')->andReturn([]);
+    $resolver->shouldReceive('sort')->andReturnUsing(static fn ($schema, array $tables): array => $tables);
+
+    $runLog = new RunLogWriter;
+
+    return new CloningRunOrchestrator($connector, $replicator, $resolver, $runLog);
+}
+
+it('marks table as skipped_by_schema_failure when schema could not be created', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema();
+    $config = makeOrchestratorConfig();
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $orchestrator = makeOrchestratorWithSchemaFailures(['users' => 'syntax error']);
+    $result = $orchestrator->run($config, $source, $target, $schema, false, [], [], static fn (): null => null);
+
+    expect($result->tables)->toHaveCount(1);
+    expect($result->tables[0]->status->value)->toBe('skipped_by_schema_failure');
+    expect($result->success)->toBeFalse();
+});
+
+it('continues with other tables after a schema failure', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+
+    $schema = new DatabaseSchemaData(
+        databaseName: 'testdb',
+        tables: [
+            new TableSchemaData(
+                name: 'orders',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+            new TableSchemaData(
+                name: 'users',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+        ],
+    );
+
+    $config = new CloningConfigData(
+        version: '1',
+        connectionName: 'source',
+        options: new CloningOptionsData(
+            chunkSize: 1000,
+            enforceColumnTypes: false,
+            dropUnknownTables: false,
+            dropExtraColumns: false,
+            disableForeignKeyChecks: false,
+            fakerLocale: 'en_US',
+        ),
+        tables: [
+            new TableCloningConfigData(
+                tableName: 'orders',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+            new TableCloningConfigData(
+                tableName: 'users',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+        ],
+    );
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([(object) ['id' => 1]], []);
+    DB::shouldReceive('table')->andReturnSelf();
+    DB::shouldReceive('insert')->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    // orders fails schema; users succeeds
+    $orchestrator = makeOrchestratorWithSchemaFailures(['orders' => 'syntax error']);
+    $result = $orchestrator->run($config, $source, $target, $schema, false, [], [], static fn (): null => null);
+
+    $statusByTable = [];
+    foreach ($result->tables as $tableResult) {
+        $statusByTable[$tableResult->tableName] = $tableResult->status->value;
+    }
+
+    expect($statusByTable['orders'])->toBe('skipped_by_schema_failure');
+    expect($statusByTable['users'])->toBe('transferred');
+    expect($result->success)->toBeFalse();
+});
+
+it('aborts after first failure when break_on_failure is true', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+
+    $schema = new DatabaseSchemaData(
+        databaseName: 'testdb',
+        tables: [
+            new TableSchemaData(
+                name: 'orders',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+            new TableSchemaData(
+                name: 'users',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+        ],
+    );
+
+    $config = new CloningConfigData(
+        version: '1',
+        connectionName: 'source',
+        options: new CloningOptionsData(
+            chunkSize: 1000,
+            enforceColumnTypes: false,
+            dropUnknownTables: false,
+            dropExtraColumns: false,
+            disableForeignKeyChecks: false,
+            fakerLocale: 'en_US',
+        ),
+        tables: [
+            new TableCloningConfigData(
+                tableName: 'orders',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+            new TableCloningConfigData(
+                tableName: 'users',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+        ],
+    );
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $orchestrator = makeOrchestratorWithSchemaFailures(['orders' => 'syntax error']);
+    $result = $orchestrator->run($config, $source, $target, $schema, false, [], [], static fn (): null => null, breakOnFailure: true);
+
+    // only orders result present — users was never processed
+    $tableNames = array_map(static fn (TableRunResultData $t): string => $t->tableName, $result->tables);
+    expect($tableNames)->toContain('orders');
+    expect($tableNames)->not->toContain('users');
+    expect($result->success)->toBeFalse();
+});
+```
+
+- [ ] **Step 2: Run new tests to confirm they fail**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php --filter="skipped_by_schema|continues with other|aborts after first"
+```
+
+Expected: **FAIL**
+
+- [ ] **Step 3: Update `CloningRunOrchestrator::run()` signature**
+
+In `app/Services/Cloning/CloningRunOrchestrator.php`, add the `$breakOnFailure` parameter to `run()`:
+
+```php
+public function run(
+    CloningConfigData $config,
+    ConnectionData $source,
+    ConnectionData $target,
+    DatabaseSchemaData $sourceSchema,
+    bool $skipSchema,
+    array $skipTables,
+    array $onlyTables,
+    callable $onProgress,
+    ?KeyRemappingService $keyRemapping = null,
+    bool $breakOnFailure = false,
+): RunResultData {
+```
+
+- [ ] **Step 4: Update the schema replication block to handle failures**
+
+Find the schema replication block in `run()` (around line 71):
+
+```php
+if (! $skipSchema) {
+    try {
+        $this->replicator->replicate(...);
+        $this->runLog->log('info', 'schema_replicated', ['tables' => $sortedTables]);
+    } catch (Throwable $e) {
+        $this->runLog->log('error', 'schema_replication_failed', ['error' => $e->getMessage()]);
+    }
+}
+```
+
+Replace it with:
+
+```php
+/** @var array<string, string> $schemaFailures */
+$schemaFailures = [];
+
+if (! $skipSchema) {
+    $schemaFailures = $this->replicator->replicate(
+        $source,
+        $target,
+        $sourceSchema,
+        $sortedTables,
+        $config->options->enforceColumnTypes,
+        $config->options->dropUnknownTables,
+        $config->options->dropExtraColumns,
+    );
+
+    if ($schemaFailures === []) {
+        $this->runLog->log('info', 'schema_replicated', ['tables' => $sortedTables]);
+    } else {
+        foreach ($schemaFailures as $failedTable => $errorMsg) {
+            $this->runLog->log('error', 'schema_table_failed', ['table' => $failedTable, 'error' => $errorMsg]);
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Add `SkippedBySchemaFailure` handling before each table transfer**
+
+Find the `foreach ($sortedTables as $tableName)` loop. Before the call to `$this->transferTable(...)`, add:
+
+```php
+// Skip data transfer for tables whose schema could not be created
+if (array_key_exists($tableName, $schemaFailures)) {
+    $tableResults[] = new TableRunResultData($tableName, TableRunStatus::SkippedBySchemaFailure, 0, 0, 0.0, $schemaFailures[$tableName]);
+    $this->runLog->log('warning', 'table_skipped_schema_failure', ['table' => $tableName]);
+    $success = false;
+    ($onProgress)($tableName, TableRunStatus::SkippedBySchemaFailure, 0, 0);
+
+    if ($breakOnFailure) {
+        break;
+    }
+
+    continue;
+}
+```
+
+Also add `$breakOnFailure` break after data transfer failures. Find:
+
+```php
+if ($failed) {
+    $success = false;
+    $this->runLog->log('error', 'table_transfer_failed', ['table' => $tableName, 'reason' => $reason]);
+} else {
+```
+
+and change to:
+
+```php
+if ($failed) {
+    $success = false;
+    $this->runLog->log('error', 'table_transfer_failed', ['table' => $tableName, 'reason' => $reason]);
+} else {
+```
+
+After `($onProgress)($tableName, $status, $rows, $skipped);` add:
+
+```php
+if ($failed && $breakOnFailure) {
+    break;
+}
+```
+
+- [ ] **Step 6: Add AUTO_INCREMENT correction after successful transfer**
+
+After the `($onProgress)` call (and the `$breakOnFailure` break check), add the AUTO_INCREMENT correction. You'll need a helper private method. Add after the `run()` method closes, before other private methods:
+
+```php
+/**
+ * Return the single integer PK column name for a table, or null if not applicable.
+ * Only applies to MySQL/MariaDB targets with a single-column integer PK.
+ */
+private function findIntegerPkColumn(ConnectionData $target, TableSchemaData $table): ?string
+{
+    if (! in_array($target->type, [DatabaseConnectionType::Mysql, DatabaseConnectionType::MariaDB], true)) {
+        return null;
+    }
+
+    $pkColumns = array_values(array_filter($table->columns, static fn (ColumnSchemaData $c): bool => $c->isPrimary));
+
+    if (count($pkColumns) !== 1) {
+        return null;
+    }
+
+    $intTypes = ['int', 'bigint', 'mediumint', 'smallint', 'tinyint', 'integer'];
+
+    if (! in_array(strtolower($pkColumns[0]->type), $intTypes, true)) {
+        return null;
+    }
+
+    return $pkColumns[0]->name;
+}
+```
+
+Add the required `use` import at the top (add `ColumnSchemaData` to the import list in `CloningRunOrchestrator`):
+
+```php
+use App\Data\Schema\ColumnSchemaData;
+use App\Data\Schema\TableSchemaData;
+```
+
+Then in the transfer loop, replace:
+
+```php
+if ($failed && $breakOnFailure) {
+    break;
+}
+```
+
+with:
+
+```php
+if ($failed && $breakOnFailure) {
+    break;
+}
+
+if (! $failed) {
+    $sourceTable = $sourceSchema->getTable($tableName);
+
+    if ($sourceTable instanceof TableSchemaData) {
+        $pkColumn = $this->findIntegerPkColumn($target, $sourceTable);
+
+        if ($pkColumn !== null) {
+            try {
+                $this->replicator->correctAutoIncrement($target, $tableName, $pkColumn);
+            } catch (Throwable $e) {
+                $this->runLog->log('warning', 'auto_increment_correction_failed', ['table' => $tableName, 'error' => $e->getMessage()]);
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Run all orchestrator tests**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+```
+
+Expected: all **PASS**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/Services/Cloning/CloningRunOrchestrator.php tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+git commit -m "feat: handle schema failures, break-on-failure, and AUTO_INCREMENT correction in orchestrator"
+```
+
+---
+
+### Task 6: Update `RunCommand` — `--break-on-failure` flag, progress and summary
+
+**Files:**
+- Modify: `app/Commands/Cloning/RunCommand.php`
+- Modify: `tests/Feature/Commands/Cloning/RunCommandTest.php`
+
+- [ ] **Step 1: Write a failing feature test for `--break-on-failure`**
+
+Add to `tests/Feature/Commands/Cloning/RunCommandTest.php`. First, find any existing test that shows the full mock setup pattern (the `it returns success with dot progress` style test), and add:
+
+```php
+it('passes break_on_failure to orchestrator when --break-on-failure is set', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $config->shouldReceive('load')->andReturn([]);
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn(makeRunSimpleSchema());
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    $capturedBreakOnFailure = null;
+
+    $orchestrator = Mockery::mock(CloningRunOrchestrator::class);
+    $orchestrator->shouldReceive('run')
+        ->withArgs(static function ($cfg, $src, $tgt, $schema, $skip, $skipTbls, $only, $cb, $km, bool $bof) use (&$capturedBreakOnFailure): bool {
+            $capturedBreakOnFailure = $bof;
+            return true;
+        })
+        ->andReturn(makeRunResult());
+    $this->app->instance(CloningRunOrchestrator::class, $orchestrator);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--ci' => true,
+        '--break-on-failure' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+
+    expect($capturedBreakOnFailure)->toBeTrue();
+});
+```
+
+- [ ] **Step 2: Run the new test to confirm it fails**
+
+```bash
+./vendor/bin/pest tests/Feature/Commands/Cloning/RunCommandTest.php --filter="passes break_on_failure"
+```
+
+Expected: **FAIL** (unknown option)
+
+- [ ] **Step 3: Add `--break-on-failure` to `RunCommand` signature**
+
+In `app/Commands/Cloning/RunCommand.php`, add to the `$signature` string after `--no-disable-fk-checks`:
+
+```php
+{--break-on-failure         : Abort the run immediately on the first table failure (schema or data)}
+```
+
+- [ ] **Step 4: Pass `breakOnFailure` to `$orchestrator->run()`**
+
+Find the `$orchestrator->run(...)` call in `RunCommand::handle()` and add the named argument:
+
+```php
+$result = $orchestrator->run(
+    config: $config,
+    source: $sourceConnection,
+    target: $targetConnection,
+    sourceSchema: $sourceSchema,
+    skipSchema: $skipSchema,
+    skipTables: $skipTables,
+    onlyTables: $onlyTables,
+    onProgress: function (...) { ... },
+    keyRemapping: $keyRemappingService,
+    breakOnFailure: (bool) $this->option('break-on-failure'),
+);
+```
+
+- [ ] **Step 5: Handle `SkippedBySchemaFailure` in `onProgress`**
+
+Inside the `onProgress` closure, add handling for the new status. The closure currently looks like:
+
+```php
+onProgress: function (string $tableName, TableRunStatus $status, int $rows, int $skipped) use ($verbose, &$notFoundTables): void {
+    if ($verbose) {
+        if ($status === TableRunStatus::Transferred) {
+            $this->line(sprintf('  <info>✓</info>  %s  (%d rows)', $tableName, $rows));
+        } elseif ($status === TableRunStatus::NotFound) {
+            $this->line(sprintf('  <comment>✗</comment>  %s  — not found in source, skipped', $tableName));
+            $notFoundTables[] = $tableName;
+        } elseif ($status === TableRunStatus::Failed) {
+            $this->line(sprintf('  <error>✗</error>  %s  — failed', $tableName));
+        }
+    } elseif ($status === TableRunStatus::Transferred) {
+        $indicator = $skipped > 0 ? 'F' : '.';
+        $this->output->write($indicator);
+    } elseif ($status === TableRunStatus::Failed) {
+        $this->output->write('E');
+    } elseif ($status === TableRunStatus::NotFound) {
+        $this->output->write('?');
+        $notFoundTables[] = $tableName;
+    }
+},
+```
+
+Change to (add `SkippedBySchemaFailure` handling, and add `&$schemaFailureTables` to the `use` clause):
+
+```php
+/** @var list<string> $schemaFailureTables */
+$schemaFailureTables = [];
+
+// ... (existing $notFoundTables declaration stays)
+
+onProgress: function (string $tableName, TableRunStatus $status, int $rows, int $skipped) use ($verbose, &$notFoundTables, &$schemaFailureTables): void {
+    if ($verbose) {
+        if ($status === TableRunStatus::Transferred) {
+            $this->line(sprintf('  <info>✓</info>  %s  (%d rows)', $tableName, $rows));
+        } elseif ($status === TableRunStatus::NotFound) {
+            $this->line(sprintf('  <comment>✗</comment>  %s  — not found in source, skipped', $tableName));
+            $notFoundTables[] = $tableName;
+        } elseif ($status === TableRunStatus::Failed) {
+            $this->line(sprintf('  <error>✗</error>  %s  — failed', $tableName));
+        } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
+            $this->line(sprintf('  <error>S</error>  %s  — schema replication failed, skipped', $tableName));
+            $schemaFailureTables[] = $tableName;
+        }
+    } elseif ($status === TableRunStatus::Transferred) {
+        $indicator = $skipped > 0 ? 'F' : '.';
+        $this->output->write($indicator);
+    } elseif ($status === TableRunStatus::Failed) {
+        $this->output->write('E');
+    } elseif ($status === TableRunStatus::NotFound) {
+        $this->output->write('?');
+        $notFoundTables[] = $tableName;
+    } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
+        $this->output->write('S');
+        $schemaFailureTables[] = $tableName;
+    }
+},
+```
+
+- [ ] **Step 6: Add schema-failure summary in Phase 8**
+
+After the `$notFoundTables` warning block in the summary section, add:
+
+```php
+// Derive schema failures from result (merging with any collected during progress)
+$schemaFailuresFromResult = array_values(array_map(
+    static fn (TableRunResultData $t): string => $t->tableName,
+    array_filter($result->tables, static fn (TableRunResultData $t): bool => $t->status === TableRunStatus::SkippedBySchemaFailure)
+));
+$schemaFailureTables = array_values(array_unique(array_merge($schemaFailureTables, $schemaFailuresFromResult)));
+
+if ($schemaFailureTables !== []) {
+    $this->line('');
+    $this->line(sprintf(
+        '  <error>Error: %d table%s skipped due to schema replication failure (%s)</error>',
+        count($schemaFailureTables),
+        count($schemaFailureTables) === 1 ? '' : 's',
+        implode(', ', $schemaFailureTables),
+    ));
+}
+```
+
+- [ ] **Step 7: Run the feature test**
+
+```bash
+./vendor/bin/pest tests/Feature/Commands/Cloning/RunCommandTest.php --filter="passes break_on_failure"
+```
+
+Expected: **PASS**
+
+- [ ] **Step 8: Run the full test suite**
+
+```bash
+composer test
+```
+
+Expected: all **PASS** (type coverage ≥ 90%, unit coverage ≥ 75%, PHPStan level max, Pint clean)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add app/Commands/Cloning/RunCommand.php tests/Feature/Commands/Cloning/RunCommandTest.php
+git commit -m "feat: add --break-on-failure flag to cloning:run and handle SkippedBySchemaFailure in output"
+```
+
+---
+
+### Task 7: Update `docs/commands/cloning-run.md`
+
+**Files:**
+- Modify: `docs/commands/cloning-run.md`
+
+- [ ] **Step 1: Add `--break-on-failure` to the Options table**
+
+Find the Options table in `docs/commands/cloning-run.md` and add a row after `--no-disable-fk-checks`:
+
+```markdown
+| `--break-on-failure` | Abort the run immediately on the first table failure (schema or data); without this flag, the run continues through all tables and returns `success: false` at the end |
+```
+
+- [ ] **Step 2: Add a section for `--break-on-failure` behaviour**
+
+Add after the Schema Synchronization section (or after the CLI flag reference table), a new subsection:
+
+```markdown
+### Error handling and `--break-on-failure`
+
+By default, `cloning:run` transfers as much data as possible even when individual tables fail. If a table's schema cannot be created (e.g. due to unsupported syntax on the target), that table is skipped with status `skipped_by_schema_failure` and data transfer continues for the remaining tables. The run completes with `success: false` and a non-zero exit code.
+
+Use `--break-on-failure` to abort the run immediately on the first failure:
+
+```bash
+clonio cloning:run production-db.cloning.yaml --target staging --break-on-failure
+```
+
+The audit log is written in both modes — including when the run is aborted early.
+
+| Scenario | Default behaviour | With `--break-on-failure` |
+|---|---|---|
+| Schema creation fails for table A | Skip A, continue with remaining tables | Abort run |
+| Data transfer fails for table B | Continue with remaining tables | Abort run |
+| All tables OK | `success: true` | `success: true` |
+| Partial failure | `success: false`, full result set | `success: false`, partial result set |
+```
+
+- [ ] **Step 3: Add `skipped_by_schema_failure` to the progress indicator table**
+
+Find the progress symbol table (`.`, `F`, `E`, `?`) and add:
+
+```markdown
+| `S` | Table skipped — schema could not be replicated to target |
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/commands/cloning-run.md
+git commit -m "docs: document --break-on-failure flag and skipped_by_schema_failure status"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec requirement | Task |
+|---|---|
+| Fix FK-stripping regex | Task 1 |
+| Per-table native DDL → inspector fallback | Task 2 |
+| `replicate()` returns `array<string,string>` | Task 2 |
+| `TableRunStatus::SkippedBySchemaFailure` | Task 3 |
+| `correctAutoIncrement()` method | Task 4 |
+| Orchestrator handles schema failures | Task 5 |
+| `breakOnFailure` parameter in orchestrator | Task 5 |
+| `correctAutoIncrement()` called after transfer | Task 5 |
+| `--break-on-failure` flag in RunCommand | Task 6 |
+| `SkippedBySchemaFailure` in progress output | Task 6 |
+| Schema failure summary in output | Task 6 |
+| `success: false` on any `SkippedBySchemaFailure` | Task 5 |
+| Audit log written even on failure | Existing behaviour, no change needed |
+| `docs/commands/cloning-run.md` updated | Task 7 |
+
+**Type consistency check:**
+- `replicate()` returns `array<string, string>` — used in Task 2 (definition) and Task 5 (consumption) ✓
+- `correctAutoIncrement(ConnectionData $target, string $tableName, string $pkColumn): void` — defined in Task 4, called in Task 5 ✓
+- `run(..., bool $breakOnFailure = false)` — defined in Task 5, called in Task 6 ✓
+- `TableRunStatus::SkippedBySchemaFailure` — defined in Task 3, used in Tasks 5 and 6 ✓
+- `findIntegerPkColumn(ConnectionData $target, TableSchemaData $table): ?string` — private method in orchestrator, only used internally in Task 5 ✓

--- a/docs/superpowers/specs/2026-04-13-schema-replication-robustness-design.md
+++ b/docs/superpowers/specs/2026-04-13-schema-replication-robustness-design.md
@@ -1,0 +1,128 @@
+# Schema Replication Robustness
+
+**Date:** 2026-04-13
+**Status:** Approved
+
+## Problem
+
+Two errors were observed in production use:
+
+1. **`schema_replication_failed`** — MySQL `SHOW CREATE TABLE` DDL was being sanitised incorrectly. The regex `FOREIGN KEY[^,)]+` stopped at the first `)` inside the FK column list (e.g. `FOREIGN KEY (`permission_id`)`), leaving `) REFERENCES `api_permissions` (`id`) ON DELETE CASCADE` as orphaned text attached to the preceding KEY line. This produced syntactically invalid SQL and caused `CREATE TABLE` to fail.
+
+2. **`table_transfer_failed` (cascade)** — Because the table was never created, the subsequent `DELETE FROM` / `INSERT` during data transfer threw `Table does not exist`. This was logged as a transfer failure even though the real cause was the schema step.
+
+## Goals
+
+- Fix the FK-stripping regex so native DDL is always valid
+- Add a per-table fallback when native DDL fails: retry using inspector-based `buildCreateTableSql()`
+- Surface which tables failed schema creation so the orchestrator can skip their data transfer gracefully
+- After data transfer, correct `AUTO_INCREMENT` values to `MAX(pk)+1` for integer-PK tables on MySQL/MariaDB targets
+- Introduce `--break-on-failure` flag on `cloning:run` for users who want hard-abort on first error
+- Update `docs/commands/cloning-run.md` to document the new flag and status
+
+## Architecture
+
+### 1. Fix `sanitiseNativeDdl()` in `SchemaReplicator`
+
+Replace the buggy regex with a line-anchored pattern using multiline mode:
+
+```php
+// Before (buggy — stops at first ) in FK column list)
+$ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN KEY[^,)]+(?:REFERENCES[^,)]+)?/i', '', $ddl);
+
+// After (correct — strips entire FK line to end-of-line)
+$ddl = preg_replace('/,?\s*CONSTRAINT\s+`[^`]+`\s+FOREIGN\s+KEY.*$/im', '', $ddl);
+```
+
+With the `m` flag, `$` anchors to end-of-line and `.` does not match newlines, so the entire constraint line (including `REFERENCES ... ON DELETE CASCADE`) is removed.
+
+Also update the existing test `it strips FOREIGN KEY constraints from native DDL` to additionally assert `->not->toContain('REFERENCES')`.
+
+### 2. Per-table fallback in `SchemaReplicator::replicate()`
+
+Change return type from `void` to `array<string, string>` (map of `tableName → errorMessage` for tables whose schema creation failed completely). `SchemaReplicator` has no `RunLogWriter` — all logging for schema failures is done by the orchestrator using the returned map.
+
+For each table that needs to be created (not yet in target):
+
+1. Attempt native DDL (`fetchNativeCreateTableDdl()` → execute on target)
+2. If execution throws → catch, retry with `buildCreateTableSql()`
+3. If retry also throws → add `tableName => $e->getMessage()` to failure map, continue to next table
+
+Tables where the fallback succeeded are **not** in the failure map.
+
+### 3. New `TableRunStatus` case
+
+```php
+case SkippedBySchemaFailure = 'skipped_by_schema_failure';
+```
+
+### 4. Orchestrator changes in `CloningRunOrchestrator::run()`
+
+- Accept new parameter `bool $breakOnFailure = false`
+- Receive `array<string, string> $schemaFailures` from `replicate()`
+- Log `warning` event `schema_table_native_ddl_failed` for each entry where fallback was triggered (not surfaced from replicate directly — orchestrator infers from final failure map)
+- Log `error` event `schema_table_failed` for each entry in the failure map
+- Before transferring each table: if `$tableName` is in `$schemaFailures`, record `SkippedBySchemaFailure`, log `warning` event `table_skipped_schema_failure`, set `$success = false`, then either continue (default) or break (if `$breakOnFailure`)
+- Existing data-transfer failures also respect `$breakOnFailure`
+- `success: false` whenever at least one table is `Failed` or `SkippedBySchemaFailure`
+- Audit log is written in all cases, including when `--break-on-failure` aborts early
+
+### 5. `--break-on-failure` flag on `cloning:run`
+
+New optional boolean flag. Passed as `$breakOnFailure` into `CloningRunOrchestrator::run()`.
+
+| Scenario | Without flag | With `--break-on-failure` |
+|---|---|---|
+| Schema failure on table A | Continue, skip A's data | Abort run |
+| Data failure on table B | Continue | Abort run |
+| All tables OK | `success: true` | `success: true` |
+| Partial failure | `success: false`, full results | `success: false`, partial results |
+
+Audit log is written in both cases.
+
+### 6. AUTO_INCREMENT correction
+
+New method `SchemaReplicator::correctAutoIncrement(ConnectionData $target, string $tableName, string $pkColumn): void`.
+
+Called from `CloningRunOrchestrator` after each successful table data transfer, when all of the following are true:
+
+- Target is MySQL or MariaDB
+- The table has exactly one PK column in `sourceSchema`
+- That column's type is an integer type: `int`, `bigint`, `mediumint`, `smallint`, `tinyint` (unsigned variants included)
+
+```sql
+SELECT COALESCE(MAX(`{pk_col}`), 0) + 1 AS next_val FROM `{table}`
+ALTER TABLE `{table}` AUTO_INCREMENT = {next_val}
+```
+
+`correctAutoIncrement()` throws on error; the orchestrator catches it, logs `warning` event `auto_increment_correction_failed`, and continues. Composite PKs are skipped by the orchestrator before calling the method (no single AUTO_INCREMENT column applies).
+
+### 7. Documentation
+
+Update `docs/commands/cloning-run.md`:
+- Document `--break-on-failure` flag with description and example
+- Add `skipped_by_schema_failure` to the table run status reference
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `app/Services/Cloning/SchemaReplicator.php` | Fix regex, per-table fallback, return `array<string, string>`, add `correctAutoIncrement()` |
+| `app/Services/Cloning/CloningRunOrchestrator.php` | Handle `$schemaFailures`, `$breakOnFailure`, call `correctAutoIncrement()` |
+| `app/Data/Cloning/TableRunStatus.php` | Add `SkippedBySchemaFailure` case |
+| `app/Commands/Cloning/RunCommand.php` | Add `--break-on-failure` flag |
+| `tests/Unit/Services/Cloning/SchemaReplicatorTest.php` | Fix existing FK test, add fallback/AUTO_INCREMENT tests |
+| `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php` | Add schema-failure and break-on-failure tests |
+| `tests/Feature/Commands/RunCommandTest.php` | Add `--break-on-failure` feature test |
+| `docs/commands/cloning-run.md` | Document new flag and status |
+
+## Test Plan
+
+- `sanitiseNativeDdl()` with FK containing `REFERENCES ... ON DELETE CASCADE` → no `REFERENCES` in output, no `FOREIGN KEY`, SQL ends with valid `)`
+- Native DDL execution fails → fallback to `buildCreateTableSql()` is called and succeeds
+- Both strategies fail → table name appears in `replicate()` return value
+- `SkippedBySchemaFailure` tables appear in `RunResultData`, `success: false`
+- `--break-on-failure` aborts loop after first failure, remaining tables absent from results
+- Without flag: all tables processed, multiple failures recorded
+- AUTO_INCREMENT set correctly after transfer; failure in setting it does not throw
+- Composite PK tables: AUTO_INCREMENT step skipped

--- a/tests/Feature/Commands/Cloning/RunCommandTest.php
+++ b/tests/Feature/Commands/Cloning/RunCommandTest.php
@@ -931,3 +931,58 @@ YAML;
     // Unchanged from YAML
     expect($capturedConfig->options->dropUnknownTables)->toBeFalse();
 });
+
+it('passes break_on_failure true to orchestrator when --break-on-failure is set', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $config->shouldReceive('load')->andReturn([]);
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn(makeRunSimpleSchema());
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    $capturedBreakOnFailure = null;
+
+    $orchestrator = Mockery::mock(CloningRunOrchestrator::class);
+    $orchestrator->shouldReceive('run')
+        ->withArgs(static function ($cfg, $src, $tgt, $schema, $skip, $skipTbls, $only, $cb, $km, bool $bof) use (&$capturedBreakOnFailure): bool {
+            $capturedBreakOnFailure = $bof;
+
+            return true;
+        })
+        ->andReturn(makeRunResult());
+    $this->app->instance(CloningRunOrchestrator::class, $orchestrator);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--ci' => true,
+        '--break-on-failure' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+
+    expect($capturedBreakOnFailure)->toBeTrue();
+});

--- a/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+++ b/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
@@ -79,7 +79,7 @@ function makeOrchestrator(): CloningRunOrchestrator
     $connector->shouldReceive('open')->andReturnUsing(static fn (ConnectionData $c): string => $c->name.'_conn');
 
     $replicator = Mockery::mock(SchemaReplicator::class);
-    $replicator->shouldReceive('replicate')->andReturnNull();
+    $replicator->shouldReceive('replicate')->andReturn([]);
 
     $resolver = Mockery::mock(DependencyResolver::class);
     $resolver->shouldReceive('computeCascadeExclusions')->andReturn([]);

--- a/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+++ b/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
@@ -6,6 +6,7 @@ use App\Data\Cloning\CloningConfigData;
 use App\Data\Cloning\CloningOptionsData;
 use App\Data\Cloning\TableCloningConfigData;
 use App\Data\Cloning\TableRowConfigData;
+use App\Data\Cloning\TableRunResultData;
 use App\Data\ConnectionData;
 use App\Data\Schema\ColumnSchemaData;
 use App\Data\Schema\DatabaseSchemaData;
@@ -348,4 +349,161 @@ it('reports table failure when SELECT throws', function (): void {
 
     expect($result->success)->toBeFalse();
     expect($result->failureReason)->not->toBeNull();
+});
+
+function makeOrchestratorWithSchemaFailures(array $schemaFailures): CloningRunOrchestrator
+{
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturnUsing(static fn (ConnectionData $c): string => $c->name.'_conn');
+
+    $replicator = Mockery::mock(SchemaReplicator::class);
+    $replicator->shouldReceive('replicate')->andReturn($schemaFailures);
+    $replicator->shouldReceive('correctAutoIncrement')->andReturnNull();
+
+    $resolver = Mockery::mock(DependencyResolver::class);
+    $resolver->shouldReceive('computeCascadeExclusions')->andReturn([]);
+    $resolver->shouldReceive('sort')->andReturnUsing(static fn ($schema, array $tables): array => $tables);
+
+    $runLog = new RunLogWriter;
+
+    return new CloningRunOrchestrator($connector, $replicator, $resolver, $runLog);
+}
+
+it('marks table as skipped_by_schema_failure when schema could not be created', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema();
+    $config = makeOrchestratorConfig();
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $orchestrator = makeOrchestratorWithSchemaFailures(['users' => 'syntax error']);
+    $result = $orchestrator->run($config, $source, $target, $schema, false, [], [], static fn (): null => null);
+
+    expect($result->tables)->toHaveCount(1);
+    expect($result->tables[0]->status->value)->toBe('skipped_by_schema_failure');
+    expect($result->success)->toBeFalse();
+});
+
+it('continues with other tables after a schema failure', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+
+    $schema = new DatabaseSchemaData(
+        databaseName: 'testdb',
+        tables: [
+            new TableSchemaData(
+                name: 'orders',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+            new TableSchemaData(
+                name: 'users',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+        ],
+    );
+
+    $config = new CloningConfigData(
+        version: '1',
+        connectionName: 'source',
+        options: new CloningOptionsData(
+            chunkSize: 1000,
+            enforceColumnTypes: false,
+            dropUnknownTables: false,
+            dropExtraColumns: false,
+            disableForeignKeyChecks: false,
+            fakerLocale: 'en_US',
+        ),
+        tables: [
+            new TableCloningConfigData(
+                tableName: 'orders',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+            new TableCloningConfigData(
+                tableName: 'users',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+        ],
+    );
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([(object) ['id' => 1]], []);
+    DB::shouldReceive('table')->andReturnSelf();
+    DB::shouldReceive('insert')->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    // orders fails schema; users succeeds
+    $orchestrator = makeOrchestratorWithSchemaFailures(['orders' => 'syntax error']);
+    $result = $orchestrator->run($config, $source, $target, $schema, false, [], [], static fn (): null => null);
+
+    $statusByTable = [];
+    foreach ($result->tables as $tableResult) {
+        $statusByTable[$tableResult->tableName] = $tableResult->status->value;
+    }
+
+    expect($statusByTable['orders'])->toBe('skipped_by_schema_failure');
+    expect($statusByTable['users'])->toBe('transferred');
+    expect($result->success)->toBeFalse();
+});
+
+it('aborts after first schema failure when breakOnFailure is true', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+
+    $schema = new DatabaseSchemaData(
+        databaseName: 'testdb',
+        tables: [
+            new TableSchemaData(
+                name: 'orders',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+            new TableSchemaData(
+                name: 'users',
+                columns: [new ColumnSchemaData(name: 'id', type: 'int', nullable: false, default: null, isPrimary: true)],
+                foreignKeys: [],
+            ),
+        ],
+    );
+
+    $config = new CloningConfigData(
+        version: '1',
+        connectionName: 'source',
+        options: new CloningOptionsData(
+            chunkSize: 1000,
+            enforceColumnTypes: false,
+            dropUnknownTables: false,
+            dropExtraColumns: false,
+            disableForeignKeyChecks: false,
+            fakerLocale: 'en_US',
+        ),
+        tables: [
+            new TableCloningConfigData(
+                tableName: 'orders',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+            new TableCloningConfigData(
+                tableName: 'users',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+        ],
+    );
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $orchestrator = makeOrchestratorWithSchemaFailures(['orders' => 'syntax error']);
+    $result = $orchestrator->run($config, $source, $target, $schema, false, [], [], static fn (): null => null, breakOnFailure: true);
+
+    $tableNames = array_map(static fn (TableRunResultData $t): string => $t->tableName, $result->tables);
+    expect($tableNames)->toContain('orders');
+    expect($tableNames)->not->toContain('users');
+    expect($result->success)->toBeFalse();
 });

--- a/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+++ b/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
@@ -390,3 +390,57 @@ SQL;
         ->not->toContain('REFERENCES')
         ->toContain('IF NOT EXISTS');
 });
+
+it('strips FOREIGN KEY constraints with ON DELETE and multiple columns from native DDL', function (): void {
+    $ddl = <<<'SQL'
+CREATE TABLE `order_items` (
+  `order_id` int NOT NULL,
+  `product_id` int NOT NULL,
+  PRIMARY KEY (`order_id`,`product_id`),
+  CONSTRAINT `order_items_order_id_foreign` FOREIGN KEY (`order_id`) REFERENCES `orders` (`id`) ON DELETE CASCADE ON UPDATE NO ACTION,
+  CONSTRAINT `order_items_product_id_foreign` FOREIGN KEY (`product_id`) REFERENCES `products` (`id`) ON DELETE RESTRICT
+) ENGINE=InnoDB
+SQL;
+
+    $sourceConn = makeReplicatorMysqlConnection('source');
+    $targetConn = makeReplicatorMysqlConnection('target');
+    $sourceSchema = new DatabaseSchemaData(databaseName: 'sourcedb', tables: [
+        new TableSchemaData(
+            name: 'order_items',
+            columns: [new ColumnSchemaData(name: 'order_id', type: 'int', nullable: false, default: null, isPrimary: true)],
+            foreignKeys: [],
+        ),
+    ]);
+
+    $emptyTargetSchema = new DatabaseSchemaData(databaseName: 'targetdb', tables: []);
+    $showRow = new stdClass;
+    $showRow->{'Create Table'} = $ddl;
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($emptyTargetSchema);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('source_conn', 'target_conn');
+
+    $capturedSql = null;
+    DB::shouldReceive('connection')->with('source_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([$showRow]);
+    DB::shouldReceive('purge')->andReturnNull();
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('statement')->with(Mockery::on(static function ($sql) use (&$capturedSql): bool {
+        $capturedSql = $sql;
+
+        return true;
+    }))->once()->andReturnTrue();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $replicator->replicate($sourceConn, $targetConn, $sourceSchema, ['order_items'], false, false);
+
+    expect($capturedSql)
+        ->not->toContain('FOREIGN KEY')
+        ->not->toContain('CONSTRAINT')
+        ->not->toContain('REFERENCES')
+        ->not->toContain('ON DELETE')
+        ->toContain('IF NOT EXISTS');
+});

--- a/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+++ b/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
@@ -442,6 +442,7 @@ SQL;
         ->not->toContain('CONSTRAINT')
         ->not->toContain('REFERENCES')
         ->not->toContain('ON DELETE')
+        ->not->toContain('ON UPDATE')
         ->toContain('IF NOT EXISTS');
 });
 

--- a/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+++ b/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
@@ -452,7 +452,7 @@ it('falls back to buildCreateTableSql when native DDL execution fails on target'
 
     $emptyTargetSchema = new DatabaseSchemaData(databaseName: 'targetdb', tables: []);
     $showRow = new stdClass;
-    $showRow->{'Create Table'} = "CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB";
+    $showRow->{'Create Table'} = 'CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB';
 
     $inspector = Mockery::mock(SchemaInspector::class);
     $inspector->shouldReceive('inspect')->andReturn($emptyTargetSchema);
@@ -475,6 +475,7 @@ it('falls back to buildCreateTableSql when native DDL execution fails on target'
             if (str_contains($sql, 'CREATE TABLE IF NOT EXISTS') && str_contains($sql, 'INT')) {
                 $fallbackCalled = true;
             }
+
             return true;
         })->andReturnTrue();
     DB::shouldReceive('purge')->with('target_conn')->andReturnNull();
@@ -493,7 +494,7 @@ it('returns table name in failure map when both native DDL and fallback fail', f
 
     $emptyTargetSchema = new DatabaseSchemaData(databaseName: 'targetdb', tables: []);
     $showRow = new stdClass;
-    $showRow->{'Create Table'} = "CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB";
+    $showRow->{'Create Table'} = 'CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB';
 
     $inspector = Mockery::mock(SchemaInspector::class);
     $inspector->shouldReceive('inspect')->andReturn($emptyTargetSchema);

--- a/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+++ b/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
@@ -387,5 +387,6 @@ SQL;
     expect($capturedSql)
         ->not->toContain('FOREIGN KEY')
         ->not->toContain('CONSTRAINT')
+        ->not->toContain('REFERENCES')
         ->toContain('IF NOT EXISTS');
 });

--- a/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+++ b/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
@@ -444,3 +444,74 @@ SQL;
         ->not->toContain('ON DELETE')
         ->toContain('IF NOT EXISTS');
 });
+
+it('falls back to buildCreateTableSql when native DDL execution fails on target', function (): void {
+    $sourceConn = makeReplicatorMysqlConnection('source');
+    $targetConn = makeReplicatorMysqlConnection('target');
+    $sourceSchema = makeSimpleSourceSchema(); // has 'users' table with id (int) column
+
+    $emptyTargetSchema = new DatabaseSchemaData(databaseName: 'targetdb', tables: []);
+    $showRow = new stdClass;
+    $showRow->{'Create Table'} = "CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB";
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($emptyTargetSchema);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('source_conn', 'target_conn');
+
+    $fallbackCalled = false;
+
+    DB::shouldReceive('connection')->with('source_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([$showRow]);
+    DB::shouldReceive('purge')->with('source_conn')->andReturnNull();
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    // First statement call (native DDL) throws; second (fallback) succeeds
+    DB::shouldReceive('statement')
+        ->once()->andThrow(new RuntimeException('syntax error'));
+    DB::shouldReceive('statement')
+        ->once()->withArgs(static function (string $sql) use (&$fallbackCalled): bool {
+            if (str_contains($sql, 'CREATE TABLE IF NOT EXISTS') && str_contains($sql, 'INT')) {
+                $fallbackCalled = true;
+            }
+            return true;
+        })->andReturnTrue();
+    DB::shouldReceive('purge')->with('target_conn')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $failures = $replicator->replicate($sourceConn, $targetConn, $sourceSchema, ['users'], false, false);
+
+    expect($fallbackCalled)->toBeTrue();
+    expect($failures)->toBeEmpty();
+});
+
+it('returns table name in failure map when both native DDL and fallback fail', function (): void {
+    $sourceConn = makeReplicatorMysqlConnection('source');
+    $targetConn = makeReplicatorMysqlConnection('target');
+    $sourceSchema = makeSimpleSourceSchema();
+
+    $emptyTargetSchema = new DatabaseSchemaData(databaseName: 'targetdb', tables: []);
+    $showRow = new stdClass;
+    $showRow->{'Create Table'} = "CREATE TABLE `users` (`id` int NOT NULL) ENGINE=InnoDB";
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($emptyTargetSchema);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('source_conn', 'target_conn');
+
+    DB::shouldReceive('connection')->with('source_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([$showRow]);
+    DB::shouldReceive('purge')->andReturnNull();
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    // Both native and fallback throw
+    DB::shouldReceive('statement')->andThrow(new RuntimeException('table engine not supported'));
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $failures = $replicator->replicate($sourceConn, $targetConn, $sourceSchema, ['users'], false, false);
+
+    expect($failures)->toHaveKey('users');
+    expect($failures['users'])->toContain('table engine not supported');
+});

--- a/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
+++ b/tests/Unit/Services/Cloning/SchemaReplicatorTest.php
@@ -515,3 +515,103 @@ it('returns table name in failure map when both native DDL and fallback fail', f
     expect($failures)->toHaveKey('users');
     expect($failures['users'])->toContain('table engine not supported');
 });
+
+it('sets AUTO_INCREMENT to max pk plus one', function (): void {
+    $targetConn = makeReplicatorMysqlConnection('target');
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('target_conn');
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    $maxRow = new stdClass;
+    $maxRow->next_val = 51;
+
+    $alterCalled = false;
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('select')->with(Mockery::pattern('/COALESCE.*MAX/i'))->andReturn([$maxRow]);
+    DB::shouldReceive('statement')->withArgs(static function (string $sql) use (&$alterCalled): bool {
+        if (str_contains($sql, 'AUTO_INCREMENT = 51')) {
+            $alterCalled = true;
+        }
+
+        return true;
+    })->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $replicator->correctAutoIncrement($targetConn, 'users', 'id');
+
+    expect($alterCalled)->toBeTrue();
+});
+
+it('sets AUTO_INCREMENT to 1 when table is empty', function (): void {
+    $targetConn = makeReplicatorMysqlConnection('target');
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('target_conn');
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    $maxRow = new stdClass;
+    $maxRow->next_val = 1;
+
+    $capturedSql = null;
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([$maxRow]);
+    DB::shouldReceive('statement')->withArgs(static function (string $sql) use (&$capturedSql): bool {
+        $capturedSql = $sql;
+
+        return true;
+    })->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $replicator->correctAutoIncrement($targetConn, 'users', 'id');
+
+    expect($capturedSql)->toContain('AUTO_INCREMENT = 1');
+});
+
+it('throws when AUTO_INCREMENT correction query fails', function (): void {
+    $targetConn = makeReplicatorMysqlConnection('target');
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('target_conn');
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    DB::shouldReceive('connection')->with('target_conn')->andReturnSelf();
+    DB::shouldReceive('select')->andThrow(new RuntimeException('query failed'));
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+
+    expect(fn () => $replicator->correctAutoIncrement($targetConn, 'users', 'id'))
+        ->toThrow(RuntimeException::class, 'query failed');
+});
+
+it('does not connect to target for non-mysql AUTO_INCREMENT correction', function (): void {
+    $targetConn = new ConnectionData(
+        name: 'target',
+        type: DatabaseConnectionType::PostgreSQL,
+        host: 'localhost',
+        port: 5432,
+        database: 'testdb',
+        schema: null,
+        username: 'root',
+        password: 'secret',
+        isProduction: false,
+    );
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->never();
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+
+    $replicator = new SchemaReplicator($inspector, $connector);
+    $replicator->correctAutoIncrement($targetConn, 'users', 'id');
+
+    expect(true)->toBeTrue(); // no exception, no connection opened
+});


### PR DESCRIPTION
## Summary

- **Fix `sanitiseNativeDdl()` regex** — the old pattern stopped at the first `)` inside an FK column list, leaving orphaned `REFERENCES ... ON DELETE CASCADE` text and producing invalid SQL. New regex uses a negative lookahead to correctly consume all `ON DELETE`/`ON UPDATE` clauses without bleeding into adjacent text.
- **Per-table schema fallback in `replicate()`** — on native DDL failure, retries with inspector-based `buildCreateTableSql()`. Tables that fail both strategies are returned in an `array<string, string>` failure map; the orchestrator skips their data transfer with the new `SkippedBySchemaFailure` status instead of crashing.
- **AUTO_INCREMENT correction** — after each successful data transfer on MySQL/MariaDB targets, if the table has a single integer PK, runs `ALTER TABLE … AUTO_INCREMENT = MAX(pk)+1` to prevent duplicate-key errors when new rows are inserted.
- **`--break-on-failure` flag on `cloning:run`** — opt-in abort on first failure (schema or data); without the flag the run continues and processes all tables.
- **Documentation** updated in `docs/commands/cloning-run.md`.

## Test Plan

- [ ] 429/429 tests passing, 0 PHPStan errors, lint clean
- [ ] `sanitiseNativeDdl()` with FK containing `ON DELETE CASCADE ON UPDATE NO ACTION` → output contains neither `FOREIGN KEY` nor `ON DELETE` nor `ON UPDATE`
- [ ] Native DDL execution fails → fallback to `buildCreateTableSql()` is called and succeeds
- [ ] Both strategies fail → table name appears in `replicate()` return value; orchestrator marks it `SkippedBySchemaFailure`
- [ ] `--break-on-failure` aborts loop after first failure; remaining tables absent from results
- [ ] Without flag: all tables processed, multiple failures recorded, `success: false`
- [ ] AUTO_INCREMENT set to `MAX(pk)+1` after transfer; failure in setting it does not abort the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)