### PR TITLE
feat: YAML-level table skipping — skip: list and rows.strategy: skip (#64)

### DIFF
--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -188,6 +188,10 @@ class RunCommand extends Command
             );
         }
 
+        // Merge YAML-level skipTables with CLI --skip-tables (additive, deduplicated)
+        // Done here so both the dry-run and full-run paths see the merged list.
+        $skipTables = array_values(array_unique(array_merge($skipTables, $config->skipTables)));
+
         // ─── Phase 2: Connection Checks ────────────────────────────────────────
 
         // Resolve source connection from config
@@ -356,9 +360,6 @@ class RunCommand extends Command
 
         /** @var list<string> $schemaFailureTables */
         $schemaFailureTables = [];
-
-        // Merge YAML-level skipTables with CLI --skip-tables (additive, deduplicated)
-        $skipTables = array_values(array_unique(array_merge($skipTables, $config->skipTables)));
 
         $result = $orchestrator->run(
             config: $config,

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -184,6 +184,7 @@ class RunCommand extends Command
                 ),
                 tables: $config->tables,
                 keyRemapping: $config->keyRemapping,
+                skipTables: $config->skipTables,
             );
         }
 
@@ -355,6 +356,9 @@ class RunCommand extends Command
 
         /** @var list<string> $schemaFailureTables */
         $schemaFailureTables = [];
+
+        // Merge YAML-level skipTables with CLI --skip-tables (additive, deduplicated)
+        $skipTables = array_values(array_unique(array_merge($skipTables, $config->skipTables)));
 
         $result = $orchestrator->run(
             config: $config,

--- a/app/Data/Cloning/CloningConfigData.php
+++ b/app/Data/Cloning/CloningConfigData.php
@@ -8,6 +8,7 @@ final readonly class CloningConfigData
 {
     /**
      * @param  list<TableCloningConfigData>  $tables
+     * @param  list<string>  $skipTables
      */
     public function __construct(
         public string $version,
@@ -15,6 +16,7 @@ final readonly class CloningConfigData
         public CloningOptionsData $options,
         public array $tables,
         public ?KeyRemappingConfigData $keyRemapping = null,
+        public array $skipTables = [],
     ) {}
 
     public function getTable(string $name): ?TableCloningConfigData

--- a/app/Services/Cloning/CloningYamlLoader.php
+++ b/app/Services/Cloning/CloningYamlLoader.php
@@ -126,6 +126,13 @@ class CloningYamlLoader
             }
         }
 
+        // Collect tables with rows.strategy: skip into skipTables (deduplicated)
+        foreach ($tables as $tableData) {
+            if ($tableData->rows->strategy === 'skip' && ! in_array($tableData->tableName, $skipTables, true)) {
+                $skipTables[] = $tableData->tableName;
+            }
+        }
+
         return new CloningConfigData(
             version: $version,
             connectionName: $connectionName,

--- a/app/Services/Cloning/CloningYamlLoader.php
+++ b/app/Services/Cloning/CloningYamlLoader.php
@@ -114,12 +114,25 @@ class CloningYamlLoader
             }
         }
 
+        // Parse top-level skip: list
+        /** @var list<string> $skipTables */
+        $skipTables = [];
+        $skipRaw = $data['skip'] ?? null;
+        if (is_array($skipRaw)) {
+            foreach ($skipRaw as $entry) {
+                if (is_string($entry) && $entry !== '') {
+                    $skipTables[] = $entry;
+                }
+            }
+        }
+
         return new CloningConfigData(
             version: $version,
             connectionName: $connectionName,
             options: $options,
             tables: $tables,
             keyRemapping: $keyRemapping,
+            skipTables: $skipTables,
         );
     }
 

--- a/app/Services/Cloning/CloningYamlValidator.php
+++ b/app/Services/Cloning/CloningYamlValidator.php
@@ -24,7 +24,7 @@ class CloningYamlValidator
         'ean13', 'ean8', 'isbn10', 'isbn13',
     ];
 
-    private const array VALID_ROW_STRATEGIES = ['full', 'first', 'last'];
+    private const array VALID_ROW_STRATEGIES = ['full', 'first', 'last', 'skip'];
 
     private const array VALID_COLUMN_STRATEGIES = ['keep', 'fake', 'hash', 'mask', 'null', 'static', 'remapping'];
 
@@ -92,6 +92,12 @@ class CloningYamlValidator
                 /** @var array<string, mixed> $keyRemapping */
                 $errors = array_merge($errors, $this->validateKeyRemapping($keyRemapping, is_array($data['tables']) ? array_keys($data['tables']) : []));
             }
+        }
+
+        // 7. skip list validation (optional)
+        $skip = $data['skip'] ?? null;
+        if ($skip !== null && ! is_array($skip)) {
+            $errors[] = "Field 'skip' must be a list of table name strings";
         }
 
         return $errors;

--- a/docs/commands/cloning-run.md
+++ b/docs/commands/cloning-run.md
@@ -422,6 +422,38 @@ When a table is excluded, all tables with a foreign key dependency on it — dir
 
 Cascaded tables appear in the audit log with status `skipped_by_cascade`.
 
+### Skipping tables in YAML
+
+Instead of passing `--skip-tables` on every invocation, you can declare tables to skip permanently inside `cloning.yaml`. Two syntaxes are supported and can be combined:
+
+**Top-level `skip:` list** — for tables that need no anonymisation config:
+
+```yaml
+skip:
+  - audit_logs
+  - telescope_entries
+  - failed_jobs
+```
+
+**`rows.strategy: skip`** — for tables already present in `tables:`:
+
+```yaml
+tables:
+  audit_logs:
+    rows:
+      strategy: skip
+  users:
+    rows:
+      strategy: full
+    columns:
+      email:
+        strategy: fake
+        faker_method: safeEmail
+        faker_arguments: []
+```
+
+YAML-level skips and `--skip-tables` are **additive**: both lists are merged at runtime. The same cascade rules apply — tables with FK dependencies on a skipped table are also skipped automatically.
+
 ## Table Run Statuses
 
 Each table in a run is recorded with one of the following statuses in the audit and process logs:

--- a/docs/superpowers/plans/2026-04-13-yaml-skip-tables.md
+++ b/docs/superpowers/plans/2026-04-13-yaml-skip-tables.md
@@ -1,0 +1,644 @@
+# YAML-Level Table Skipping Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow tables to be permanently excluded from cloning runs via `cloning.yaml` using a top-level `skip:` list and/or `rows.strategy: skip` on individual table entries.
+
+**Architecture:** Add a `skipTables` field to `CloningConfigData`, populate it in `CloningYamlLoader` from both sources (top-level `skip:` list and per-table `rows.strategy: skip`), then merge it with the CLI `--skip-tables` list in `RunCommand` before calling the orchestrator. The orchestrator itself is unchanged — it already has full skip + cascade logic.
+
+**Tech Stack:** PHP 8.5, Laravel Zero, PestPHP v4, Mockery
+
+---
+
+## File Map
+
+| File | Change |
+|---|---|
+| `app/Data/Cloning/CloningConfigData.php` | Add `public readonly array $skipTables = []` |
+| `app/Services/Cloning/CloningYamlLoader.php` | Parse top-level `skip:` list; scan for `rows.strategy: skip` tables; deduplicate into `skipTables` |
+| `app/Services/Cloning/CloningYamlValidator.php` | Add `skip` to `VALID_ROW_STRATEGIES`; validate top-level `skip:` field |
+| `app/Commands/Cloning/RunCommand.php` | Merge `$config->skipTables` into `$skipTables`; preserve field in config reconstruction |
+| `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php` | Tests for both skip syntaxes, deduplication, conflict resolution |
+| `tests/Unit/Services/Cloning/CloningYamlValidatorTest.php` | Tests for `skip:` validation and `strategy: skip` acceptance |
+| `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php` | Test that `config->skipTables` entries are excluded with cascade |
+| `docs/commands/cloning-run.md` | Document YAML-level skip syntax |
+
+---
+
+### Task 1: Add `skipTables` to `CloningConfigData` + parse top-level `skip:` in loader
+
+**Files:**
+- Modify: `app/Data/Cloning/CloningConfigData.php`
+- Modify: `app/Services/Cloning/CloningYamlLoader.php`
+- Test: `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php`:
+
+```php
+it('parses top-level skip list into skipTables', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - audit_logs
+  - telescope_entries
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs', 'telescope_entries']);
+});
+
+it('returns empty skipTables when skip key is absent', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe([]);
+});
+
+it('ignores non-string entries in the skip list', function (): void {
+    Storage::fake('local');
+
+    // We pass the data array directly to the internal mapper by testing via a sub-class
+    // Instead, use Storage to fake a YAML that has a valid skip list mixed with junk —
+    // YAML parses integers as ints so we test that gracefully
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - audit_logs
+  - 42
+  - ""
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs']);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlLoaderTest.php --filter="parses top-level skip|returns empty skipTables|ignores non-string"
+```
+
+Expected: FAIL — `skipTables` property does not exist yet.
+
+- [ ] **Step 3: Add `skipTables` to `CloningConfigData`**
+
+In `app/Data/Cloning/CloningConfigData.php`, update the class:
+
+```php
+final readonly class CloningConfigData
+{
+    /**
+     * @param  list<TableCloningConfigData>  $tables
+     * @param  list<string>  $skipTables
+     */
+    public function __construct(
+        public string $version,
+        public string $connectionName,
+        public CloningOptionsData $options,
+        public array $tables,
+        public ?KeyRemappingConfigData $keyRemapping = null,
+        public array $skipTables = [],
+    ) {}
+
+    public function getTable(string $name): ?TableCloningConfigData
+    {
+        foreach ($this->tables as $table) {
+            if ($table->tableName === $name) {
+                return $table;
+            }
+        }
+
+        return null;
+    }
+}
+```
+
+- [ ] **Step 4: Parse top-level `skip:` in `CloningYamlLoader::mapToDto()`**
+
+In `app/Services/Cloning/CloningYamlLoader.php`, inside `mapToDto()`, add skip parsing **before** the `return new CloningConfigData(...)` statement:
+
+```php
+// Parse top-level skip: list
+/** @var list<string> $skipTables */
+$skipTables = [];
+$skipRaw = $data['skip'] ?? null;
+if (is_array($skipRaw)) {
+    foreach ($skipRaw as $entry) {
+        if (is_string($entry) && $entry !== '') {
+            $skipTables[] = $entry;
+        }
+    }
+}
+```
+
+Then update the `return new CloningConfigData(...)` to pass the new field:
+
+```php
+return new CloningConfigData(
+    version: $version,
+    connectionName: $connectionName,
+    options: $options,
+    tables: $tables,
+    keyRemapping: $keyRemapping,
+    skipTables: $skipTables,
+);
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlLoaderTest.php --filter="parses top-level skip|returns empty skipTables|ignores non-string"
+```
+
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Run full suite to check for regressions**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
+```
+
+Expected: all existing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add app/Data/Cloning/CloningConfigData.php app/Services/Cloning/CloningYamlLoader.php tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
+git commit -m "feat: add skipTables to CloningConfigData and parse top-level skip: list"
+```
+
+---
+
+### Task 2: Handle `rows.strategy: skip` in loader + update validator
+
+**Files:**
+- Modify: `app/Services/Cloning/CloningYamlLoader.php`
+- Modify: `app/Services/Cloning/CloningYamlValidator.php`
+- Test: `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php`
+- Test: `tests/Unit/Services/Cloning/CloningYamlValidatorTest.php`
+
+- [ ] **Step 1: Write failing loader tests**
+
+Add to `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php`:
+
+```php
+it('collects tables with rows.strategy skip into skipTables', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+  audit_logs:
+    rows:
+      strategy: skip
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs']);
+});
+
+it('deduplicates tables that appear in both skip list and as strategy skip', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - audit_logs
+tables:
+  users:
+    rows:
+      strategy: full
+  audit_logs:
+    rows:
+      strategy: skip
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs']);
+});
+
+it('skips a table from the top-level skip list even when its table entry has a non-skip strategy', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - users
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['users']);
+});
+```
+
+- [ ] **Step 2: Run failing loader tests**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlLoaderTest.php --filter="collects tables with rows.strategy skip|deduplicates tables|skips a table from the top-level"
+```
+
+Expected: FAIL — `strategy: skip` not yet recognised by validator or collected by loader.
+
+- [ ] **Step 3: Write failing validator tests**
+
+Add to `tests/Unit/Services/Cloning/CloningYamlValidatorTest.php`:
+
+```php
+it('accepts rows.strategy skip as a valid strategy', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $data = [
+        'version' => '1',
+        'connection' => 'production-db',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'audit_logs' => [
+                'rows' => ['strategy' => 'skip'],
+            ],
+        ],
+    ];
+
+    expect($validator->validate($data))->toBe([]);
+});
+
+it('accepts a valid top-level skip list', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $data = [
+        'version' => '1',
+        'connection' => 'production-db',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'users' => [
+                'rows' => ['strategy' => 'full'],
+            ],
+        ],
+        'skip' => ['audit_logs', 'telescope_entries'],
+    ];
+
+    expect($validator->validate($data))->toBe([]);
+});
+
+it('returns error when skip is not a list', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $data = [
+        'version' => '1',
+        'connection' => 'production-db',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'users' => [
+                'rows' => ['strategy' => 'full'],
+            ],
+        ],
+        'skip' => 'audit_logs',
+    ];
+
+    $errors = $validator->validate($data);
+
+    expect($errors)->toContain("Field 'skip' must be a list of table name strings");
+});
+```
+
+- [ ] **Step 4: Run failing validator tests**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlValidatorTest.php --filter="accepts rows.strategy skip|accepts a valid top-level skip|returns error when skip is not a list"
+```
+
+Expected: FAIL.
+
+- [ ] **Step 5: Add `skip` to `VALID_ROW_STRATEGIES` in validator**
+
+In `app/Services/Cloning/CloningYamlValidator.php`, change:
+
+```php
+private const array VALID_ROW_STRATEGIES = ['full', 'first', 'last'];
+```
+
+to:
+
+```php
+private const array VALID_ROW_STRATEGIES = ['full', 'first', 'last', 'skip'];
+```
+
+Then in `validate()`, after the existing `key_remapping` validation block (around line where `$keyRemapping` is validated), add:
+
+```php
+// 7. skip list validation (optional)
+$skip = $data['skip'] ?? null;
+if ($skip !== null) {
+    if (! is_array($skip)) {
+        $errors[] = "Field 'skip' must be a list of table name strings";
+    }
+}
+```
+
+- [ ] **Step 6: Update loader to collect `strategy: skip` tables**
+
+In `app/Services/Cloning/CloningYamlLoader.php`, inside `mapToDto()`, **after** the existing `$skipTables` parsing and **before** the `return new CloningConfigData(...)` statement, add:
+
+```php
+// Collect tables with rows.strategy: skip into skipTables (deduplicated)
+foreach ($tables as $tableData) {
+    if ($tableData->rows->strategy === 'skip' && ! in_array($tableData->tableName, $skipTables, true)) {
+        $skipTables[] = $tableData->tableName;
+    }
+}
+```
+
+- [ ] **Step 7: Run all new tests**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlLoaderTest.php tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
+```
+
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add app/Services/Cloning/CloningYamlLoader.php app/Services/Cloning/CloningYamlValidator.php tests/Unit/Services/Cloning/CloningYamlLoaderTest.php tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
+git commit -m "feat: support rows.strategy skip and validate top-level skip: in YAML"
+```
+
+---
+
+### Task 3: Wire `config->skipTables` into RunCommand + orchestrator test
+
+**Files:**
+- Modify: `app/Commands/Cloning/RunCommand.php`
+- Test: `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php`
+
+- [ ] **Step 1: Write failing orchestrator test**
+
+The orchestrator itself does not change — `config->skipTables` is merged into the `$skipTables` parameter in `RunCommand`. But we need a test that passing `skipTables` on the config DTO produces the same exclusion as passing via the CLI parameter.
+
+Add to `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php`:
+
+```php
+it('excludes tables listed in config skipTables the same as cli skip-tables', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema();
+
+    // Config has 'users' in skipTables — but we pass it via the $skipTables param
+    // (RunCommand merges config->skipTables into $skipTables before calling orchestrator)
+    $config = makeOrchestratorConfig();
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([]);
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $orchestrator = makeOrchestrator();
+    // Simulate what RunCommand does: merge config->skipTables with CLI skip list
+    $mergedSkip = array_values(array_unique(array_merge(['users'], [])));
+    $result = $orchestrator->run($config, $source, $target, $schema, true, $mergedSkip, [], static fn (): null => null);
+
+    expect($result->tables)->toHaveCount(1);
+    expect($result->tables[0]->status->value)->toBe('skipped_by_flag');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes (it exercises existing logic)**
+
+```bash
+./vendor/bin/pest tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php --filter="excludes tables listed in config skipTables"
+```
+
+Expected: PASS — this verifies the existing `$skipTables` parameter works; no new orchestrator code needed.
+
+- [ ] **Step 3: Merge `config->skipTables` into `$skipTables` in RunCommand**
+
+In `app/Commands/Cloning/RunCommand.php`, locate the block around line 150 where `$skipTables` is built from the CLI option:
+
+```php
+/** @var list<string> $skipTables */
+$skipTables = ($skipTablesOpt !== null && $skipTablesOpt !== '')
+    ? array_values(array_filter(array_map(trim(...), explode(',', (string) $skipTablesOpt))))
+    : [];
+```
+
+This is **before** `$config` is available (config is loaded earlier). The merge must happen **after** `$config` is loaded. Find where `$config` is first set (via `$loader->load()`), then find where `$skipTables` is used (line 365: `skipTables: $skipTables`). Add the merge **immediately before** the `$result = $orchestrator->run(...)` call:
+
+```php
+// Merge YAML-level skipTables with CLI --skip-tables (additive, deduplicated)
+$skipTables = array_values(array_unique(array_merge($skipTables, $config->skipTables)));
+```
+
+- [ ] **Step 4: Preserve `skipTables` in config reconstruction**
+
+In `app/Commands/Cloning/RunCommand.php`, find the block where `$config` is reconstructed (around line 175) when CLI option overrides are applied:
+
+```php
+$config = new CloningConfigData(
+    version: $config->version,
+    connectionName: $config->connectionName,
+    options: new CloningOptionsData(...),
+    tables: $config->tables,
+    keyRemapping: $config->keyRemapping,
+);
+```
+
+Add `skipTables: $config->skipTables,` to preserve the field:
+
+```php
+$config = new CloningConfigData(
+    version: $config->version,
+    connectionName: $config->connectionName,
+    options: new CloningOptionsData(
+        chunkSize: $opts->chunkSize,
+        enforceColumnTypes: $enforceOverride ?? $opts->enforceColumnTypes,
+        dropUnknownTables: $dropUnkOverride ?? $opts->dropUnknownTables,
+        dropExtraColumns: $dropExtOverride ?? $opts->dropExtraColumns,
+        disableForeignKeyChecks: $fkChecksOverride ?? $opts->disableForeignKeyChecks,
+        fakerLocale: $opts->fakerLocale,
+    ),
+    tables: $config->tables,
+    keyRemapping: $config->keyRemapping,
+    skipTables: $config->skipTables,
+);
+```
+
+- [ ] **Step 5: Run full unit suite**
+
+```bash
+composer test:unit
+```
+
+Expected: all pass, no regressions.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Commands/Cloning/RunCommand.php tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+git commit -m "feat: merge config->skipTables with CLI --skip-tables in RunCommand"
+```
+
+---
+
+### Task 4: Update documentation
+
+**Files:**
+- Modify: `docs/commands/cloning-run.md`
+
+- [ ] **Step 1: Add YAML skip syntax to docs**
+
+In `docs/commands/cloning-run.md`, find the existing section that documents `--skip-tables` (in the options table). After it, add or extend a section explaining YAML-level skipping.
+
+Add the following content at a logical place (after the `--skip-tables` / `--only-tables` description or in a dedicated subsection):
+
+````markdown
+### Skipping tables in YAML
+
+Instead of passing `--skip-tables` on every invocation, you can declare tables to skip permanently inside `cloning.yaml`. Two syntaxes are supported and can be combined:
+
+**Top-level `skip:` list** — for tables that need no anonymisation config:
+
+```yaml
+skip:
+  - audit_logs
+  - telescope_entries
+  - failed_jobs
+```
+
+**`rows.strategy: skip`** — for tables already present in `tables:`:
+
+```yaml
+tables:
+  audit_logs:
+    rows:
+      strategy: skip
+  users:
+    rows:
+      strategy: full
+    columns:
+      email:
+        strategy: fake
+        faker_method: safeEmail
+        faker_arguments: []
+```
+
+YAML-level skips and `--skip-tables` are **additive**: both lists are merged at runtime. The same cascade rules apply — tables with FK dependencies on a skipped table are also skipped automatically.
+````
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+composer test
+```
+
+Expected: all 429+ tests pass, 0 PHPStan errors, lint clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/commands/cloning-run.md
+git commit -m "docs: document YAML-level table skipping (skip: list and strategy: skip)"
+```

--- a/docs/superpowers/specs/2026-04-13-yaml-skip-tables-design.md
+++ b/docs/superpowers/specs/2026-04-13-yaml-skip-tables-design.md
@@ -1,0 +1,112 @@
+# YAML-Level Table Skipping
+
+**Date:** 2026-04-13
+**Status:** Approved
+**Issue:** [#64](https://github.com/clonio-dev/clonio-cli/issues/64)
+
+## Problem
+
+Tables can only be excluded from a run via `--skip-tables` and `--only-tables` CLI flags. There is no way to declare in the `cloning.yaml` itself that a table should always be skipped, requiring users to remember and repeat the flag on every invocation.
+
+## Goals
+
+- Allow tables to be marked for skipping inside `cloning.yaml`, so they are excluded automatically on every run without a CLI flag
+- Support two complementary syntaxes: a top-level `skip:` list and a per-table `rows.strategy: skip`
+- Produce identical runtime behaviour to `--skip-tables`: cascade exclusions apply (FK-dependent tables are also skipped)
+- YAML-level skips and `--skip-tables` are additive — both lists are merged at runtime
+
+## YAML Syntax
+
+### Top-level `skip:` list
+
+For tables that need no other configuration:
+
+```yaml
+skip:
+  - audit_logs
+  - telescope_entries
+  - failed_jobs
+```
+
+### Per-table `rows.strategy: skip`
+
+For tables already present in `tables:`:
+
+```yaml
+tables:
+  audit_logs:
+    rows:
+      strategy: skip
+  users:
+    rows:
+      strategy: full
+    columns:
+      email:
+        strategy: fake
+        faker_method: safeEmail
+```
+
+### Conflict resolution
+
+- If a table appears in both `skip:` and `tables:` with `strategy: skip` → skipped once (deduplicated)
+- If a table appears in `skip:` and `tables:` with a non-skip strategy → `skip:` wins, table is skipped
+
+## Architecture
+
+### `CloningConfigData`
+
+New field:
+
+```php
+/** @param list<string> $skipTables */
+public readonly array $skipTables = []
+```
+
+Populated by the loader from both sources, deduplicated.
+
+### `CloningYamlLoader::mapToDto()`
+
+Two additions:
+
+1. Parse `$data['skip']` as `list<string>` — ignore non-array / non-string entries gracefully
+2. After building `$tables`, scan for entries where `rows.strategy === 'skip'` and add those table names to the skip list
+3. Merge and deduplicate both sources into `CloningConfigData::$skipTables`
+
+### `CloningRunOrchestrator`
+
+No changes to parameters. `RunCommand` merges `$config->skipTables` with the CLI `--skip-tables` list before passing to the orchestrator. The orchestrator's existing skip + cascade exclusion logic handles the rest unchanged.
+
+### `CloningYamlValidator`
+
+Two additions:
+
+- `skip:` must be a list of strings if present; fail validation with a clear error message if not
+- `rows.strategy: skip` is added to the set of accepted strategy values
+
+### `CloningYamlWriter`
+
+No changes needed — if a table config has `strategy: skip`, it is written faithfully. The writer does not generate top-level `skip:` entries (it generates from source schema).
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `app/Data/Cloning/CloningConfigData.php` | Add `$skipTables` field |
+| `app/Services/Cloning/CloningYamlLoader.php` | Parse `skip:` list and collect `strategy: skip` tables |
+| `app/Services/Cloning/CloningYamlValidator.php` | Validate `skip:` and accept `strategy: skip` |
+| `app/Commands/Cloning/RunCommand.php` | Merge `$config->skipTables` with CLI `--skip-tables` before orchestrator call |
+| `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php` | Tests for both skip syntaxes, deduplication, conflict resolution |
+| `tests/Unit/Services/Cloning/CloningYamlValidatorTest.php` | Validation tests for `skip:` and `strategy: skip` |
+| `tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php` | Test that `config->skipTables` entries are excluded with cascade |
+| `docs/commands/cloning-run.md` | Document YAML-level skip syntax and additive merge with `--skip-tables` |
+
+## Test Plan
+
+- `skip:` list is parsed into `CloningConfigData::$skipTables`
+- `rows.strategy: skip` entries are collected into `$skipTables`
+- Both sources are merged and deduplicated
+- A table in `skip:` with a non-skip strategy in `tables:` → still skipped (skip wins)
+- Invalid `skip:` value (non-string entry) → ignored gracefully; non-array `skip:` → validation error
+- `rows.strategy: skip` is accepted by validator
+- Tables from `config->skipTables` are excluded in orchestrator with cascade
+- YAML-level skips and CLI `--skip-tables` are additive (both applied)

--- a/tests/Feature/Commands/Cloning/RunCommandTest.php
+++ b/tests/Feature/Commands/Cloning/RunCommandTest.php
@@ -986,3 +986,61 @@ YAML;
 
     expect($capturedBreakOnFailure)->toBeTrue();
 });
+
+it('merges yaml-level skipTables with cli --skip-tables when calling orchestrator', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - audit_logs
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $config->shouldReceive('load')->andReturn([]);
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn(makeRunSimpleSchema());
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    $capturedSkipTables = null;
+
+    $orchestrator = Mockery::mock(CloningRunOrchestrator::class);
+    $orchestrator->shouldReceive('run')
+        ->withArgs(static function ($cfg, $src, $tgt, $schema, $skipSchema, array $skipTbls, $only, $cb, $km, $bof) use (&$capturedSkipTables): bool {
+            $capturedSkipTables = $skipTbls;
+
+            return true;
+        })
+        ->andReturn(makeRunResult());
+    $this->app->instance(CloningRunOrchestrator::class, $orchestrator);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--ci' => true,
+        '--skip-tables' => 'sessions',
+    ])->assertExitCode(ExitCode::Success->value);
+
+    expect($capturedSkipTables)->toContain('audit_logs');
+    expect($capturedSkipTables)->toContain('sessions');
+});

--- a/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+++ b/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
@@ -268,25 +268,6 @@ it('marks table as skipped when in skip-tables list', function (): void {
     expect($result->tables[0]->status->value)->toBe('skipped_by_flag');
 });
 
-it('excludes tables listed in config skipTables the same as cli skip-tables', function (): void {
-    $source = makeOrchestratorConnection('source');
-    $target = makeOrchestratorConnection('target');
-    $schema = makeOrchestratorSchema();
-    $config = makeOrchestratorConfig();
-
-    DB::shouldReceive('connection')->andReturnSelf();
-    DB::shouldReceive('select')->andReturn([]);
-    DB::shouldReceive('purge')->andReturnNull();
-
-    $orchestrator = makeOrchestrator();
-    // Simulate what RunCommand does: merge config->skipTables with CLI skip list
-    $mergedSkip = array_values(array_unique(array_merge(['users'], [])));
-    $result = $orchestrator->run($config, $source, $target, $schema, true, $mergedSkip, [], static fn (): null => null);
-
-    expect($result->tables)->toHaveCount(1);
-    expect($result->tables[0]->status->value)->toBe('skipped_by_flag');
-});
-
 it('marks table as not-found when missing from schema', function (): void {
     $source = makeOrchestratorConnection('source');
     $target = makeOrchestratorConnection('target');

--- a/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+++ b/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
@@ -268,6 +268,25 @@ it('marks table as skipped when in skip-tables list', function (): void {
     expect($result->tables[0]->status->value)->toBe('skipped_by_flag');
 });
 
+it('excludes tables listed in config skipTables the same as cli skip-tables', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema();
+    $config = makeOrchestratorConfig();
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([]);
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $orchestrator = makeOrchestrator();
+    // Simulate what RunCommand does: merge config->skipTables with CLI skip list
+    $mergedSkip = array_values(array_unique(array_merge(['users'], [])));
+    $result = $orchestrator->run($config, $source, $target, $schema, true, $mergedSkip, [], static fn (): null => null);
+
+    expect($result->tables)->toHaveCount(1);
+    expect($result->tables[0]->status->value)->toBe('skipped_by_flag');
+});
+
 it('marks table as not-found when missing from schema', function (): void {
     $source = makeOrchestratorConnection('source');
     $target = makeOrchestratorConnection('target');

--- a/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
@@ -675,3 +675,88 @@ YAML;
 
     expect($config->skipTables)->toBe(['audit_logs']);
 });
+
+it('collects tables with rows.strategy skip into skipTables', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+  audit_logs:
+    rows:
+      strategy: skip
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs']);
+});
+
+it('deduplicates tables that appear in both skip list and as strategy skip', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - audit_logs
+tables:
+  users:
+    rows:
+      strategy: full
+  audit_logs:
+    rows:
+      strategy: skip
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs']);
+});
+
+it('skips a table from the top-level skip list even when its table entry has a non-skip strategy', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - users
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['users']);
+});

--- a/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
@@ -593,3 +593,85 @@ YAML;
 
     expect($config->options->dropExtraColumns)->toBeFalse();
 });
+
+it('parses top-level skip list into skipTables', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - audit_logs
+  - telescope_entries
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs', 'telescope_entries']);
+});
+
+it('returns empty skipTables when skip key is absent', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe([]);
+});
+
+it('ignores non-string entries in the skip list', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  faker_locale: en_US
+skip:
+  - audit_logs
+  - 42
+  - ""
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('test.cloning.yaml');
+
+    expect($config->skipTables)->toBe(['audit_logs']);
+});

--- a/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
@@ -573,3 +573,76 @@ it('rejects drop_extra_columns when not a boolean', function (): void {
 
     expect($errors)->toContain("Field 'options.drop_extra_columns' must be a boolean");
 });
+
+it('accepts rows.strategy skip as a valid strategy', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $data = [
+        'version' => '1',
+        'connection' => 'production-db',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'audit_logs' => [
+                'rows' => ['strategy' => 'skip'],
+            ],
+        ],
+    ];
+
+    expect($validator->validate($data))->toBe([]);
+});
+
+it('accepts a valid top-level skip list', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $data = [
+        'version' => '1',
+        'connection' => 'production-db',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'users' => [
+                'rows' => ['strategy' => 'full'],
+            ],
+        ],
+        'skip' => ['audit_logs', 'telescope_entries'],
+    ];
+
+    expect($validator->validate($data))->toBe([]);
+});
+
+it('returns error when skip is not a list', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $data = [
+        'version' => '1',
+        'connection' => 'production-db',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'users' => [
+                'rows' => ['strategy' => 'full'],
+            ],
+        ],
+        'skip' => 'audit_logs',
+    ];
+
+    $errors = $validator->validate($data);
+
+    expect($errors)->toContain("Field 'skip' must be a list of table name strings");
+});


### PR DESCRIPTION
## Summary

Closes #64.

- **Top-level `skip:` list** — permanently exclude tables from every run without repeating `--skip-tables` on the CLI:
  ```yaml
  skip:
    - audit_logs
    - telescope_entries
    - failed_jobs
  ```
- **`rows.strategy: skip`** — skip a table that already has configuration in `tables:`, keeping the rest of its config intact for when you un-skip it later
- Both syntaxes can be combined and are deduplicated. YAML-level skips and CLI `--skip-tables` are additive — both lists are merged before calling the orchestrator, so cascade exclusion (FK-dependent tables) applies to all sources. The merge happens before the dry-run path too.

## Test Plan

- [ ] 439/439 tests passing, 0 PHPStan errors, lint clean
- [ ] `skip: [audit_logs]` in YAML → `audit_logs` excluded from run
- [ ] `rows.strategy: skip` on a table → that table excluded
- [ ] Both syntaxes together → deduplicated, table appears once
- [ ] YAML skip + `--skip-tables` → both tables excluded (additive)
- [ ] Validator rejects `skip: "string"` (non-list) with clear error
- [ ] Validator accepts `rows.strategy: skip` without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)