### PR TITLE
ci: fix SPC build (onig via mbregex) and add test-release tooling

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     tags:
       - 'v*'
+  # Manual dry-run: runs test + build, uploads binaries as artifacts, skips release + packagist.
+  # Use from the Actions tab to verify CI changes on a branch before tagging.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -81,16 +84,16 @@ jobs:
 
     env:
       PHP_VERSION: '8.5'
-      EXTENSIONS: ctype,curl,fileinfo,filter,gd,iconv,mbstring,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,phar,readline,session,sqlite3,tokenizer,zlib
+      # mbregex is a separate SPC extension (not part of mbstring) that provides mb_ereg*
+      # and mb_regex_encoding. mPDF checks for it at runtime and fails without it.
+      # Adding it here makes SPC auto-pull the onig library via its lib-depends.
+      EXTENSIONS: ctype,curl,fileinfo,filter,gd,iconv,mbstring,mbregex,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,phar,readline,session,sqlite3,tokenizer,zlib
       # Optional gd image libs. libpng + zlib are hard-deps and always built;
       # these add JPEG, WebP, and TrueType font support for mpdf-generated PDFs.
       # libavif intentionally omitted (heavy aom/dav1d toolchain, rarely used in PDFs).
       # Keep GD_LIBS_SLUG in sync — cache keys cannot contain commas.
       GD_LIBS: 'libjpeg,libwebp,freetype'
       GD_LIBS_SLUG: 'libjpeg-libwebp-freetype'
-      # oniguruma is required by mbstring's mbregex functions (mb_ereg*, mb_regex_encoding).
-      # mPDF checks for mbregex support at runtime and fails without it.
-      EXTRA_LIBS: 'oniguruma'
       # Pin OpenSSL to 3.x. OpenSSL 4.0.0 removed ERR_NUM_ERRORS, which PHP 8.5's
       # openssl extension still references — fresh downloads otherwise grab 4.x and fail to compile.
       OPENSSL_VERSION: '3.6.2'
@@ -124,7 +127,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ./downloads
-          key: spc-downloads-${{ runner.os }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-oniguruma-v6
+          key: spc-downloads-${{ runner.os }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-mbregex-v1
 
       - name: Download PHP sources & extensions
         if: steps.spc-downloads-cache.outputs.cache-hit != 'true'
@@ -134,7 +137,7 @@ jobs:
           ./spc download \
             --with-php=${{ env.PHP_VERSION }} \
             --for-extensions="${{ env.EXTENSIONS }}" \
-            --for-libs="${{ env.GD_LIBS }},${{ env.EXTRA_LIBS }}" \
+            --for-libs="${{ env.GD_LIBS }}" \
             --custom-url="openssl:https://github.com/openssl/openssl/releases/download/openssl-${{ env.OPENSSL_VERSION }}/openssl-${{ env.OPENSSL_VERSION }}.tar.gz"
 
       - name: Cache SPC build output
@@ -142,11 +145,11 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ./buildroot
-          key: spc-build-${{ runner.os }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-oniguruma-v6
+          key: spc-build-${{ runner.os }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-mbregex-v1
 
       - name: Compile PHP micro SAPI
         if: steps.spc-build-cache.outputs.cache-hit != 'true'
-        run: ./spc build --build-micro --with-libs="${{ env.GD_LIBS }},${{ env.EXTRA_LIBS }}" ${{ runner.debug == '1' && '--debug' || '' }} "${{ env.EXTENSIONS }}"
+        run: ./spc build --build-micro --with-libs="${{ env.GD_LIBS }}" ${{ runner.debug == '1' && '--debug' || '' }} "${{ env.EXTENSIONS }}"
 
       - name: Upload SPC logs on failure
         if: failure()
@@ -166,7 +169,12 @@ jobs:
         run: composer install --no-interaction --prefer-dist --optimize-autoloader --no-dev
 
       - name: Stamp version from tag
-        run: echo "${{ github.ref_name }}" > VERSION
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "dev-${GITHUB_SHA::7}" > VERSION
+          else
+            echo "${{ github.ref_name }}" > VERSION
+          fi
 
       - name: Build PHAR
         run: php clonio app:build clonio --no-interaction
@@ -243,7 +251,8 @@ jobs:
     name: Publish Release
     needs: [test, build]
     runs-on: ubuntu-latest
-    if: always() && needs.test.result == 'success'
+    # Skip on workflow_dispatch — manual runs are dry-runs (artifacts only, no release).
+    if: always() && needs.test.result == 'success' && needs.build.result == 'success' && github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
 
     steps:
       - name: Checkout
@@ -277,6 +286,8 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: ./artifacts/*
+          # Tags like v0.6.8-alpha.1 / -beta.1 / -rc.1 are marked as pre-release.
+          prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           body: |
             ## What's changed
 
@@ -331,7 +342,8 @@ jobs:
     name: Notify Packagist
     needs: release
     runs-on: ubuntu-latest
-    if: always() && needs.release.result == 'success'
+    # Skip for pre-release tags (alpha/beta/rc) — keeps Packagist listing focused on stable releases.
+    if: always() && needs.release.result == 'success' && !contains(github.ref_name, '-alpha') && !contains(github.ref_name, '-beta') && !contains(github.ref_name, '-rc')
     steps:
       - name: Ping Packagist
         env:

--- a/Makefile
+++ b/Makefile
@@ -1,34 +1,39 @@
 .DEFAULT_GOAL := help
-.PHONY: help current patch minor major
+.PHONY: help current patch minor major alpha
 
+# ──────────────────────────────────────────────────────────────────────────────
+# "latest stable" excludes pre-release tags (anything with a `-` suffix like
+# v0.6.8-alpha.1). Those are test builds and shouldn't be used as the bump base.
 # ──────────────────────────────────────────────────────────────────────────────
 
 help:
-	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | head -1); \
+	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | grep -v -- '-' | head -1); \
 	CURRENT=$${CURRENT:-v0.0.0}; \
 	VERSION=$$(echo "$$CURRENT" | sed 's/^v//'); \
 	MAJOR=$$(echo "$$VERSION" | cut -d. -f1); \
 	MINOR=$$(echo "$$VERSION" | cut -d. -f2); \
 	PATCH=$$(echo "$$VERSION" | cut -d. -f3); \
+	NEXT_PATCH="v$$MAJOR.$$MINOR.$$((PATCH+1))"; \
 	echo ""; \
 	echo "  Clonio CLI — Release Tagging"; \
 	echo ""; \
-	echo "  Current version: $$CURRENT"; \
+	echo "  Current stable: $$CURRENT"; \
 	echo ""; \
 	echo "  Commands:"; \
-	printf "    %-12s %s\n" "make current" "Show current version on main"; \
-	printf "    %-12s %s\n" "make patch" "Bump patch version  ($$CURRENT → v$$MAJOR.$$MINOR.$$((PATCH+1)))"; \
+	printf "    %-12s %s\n" "make current" "Show current stable version on main"; \
+	printf "    %-12s %s\n" "make alpha" "Tag a pre-release ($$CURRENT → $$NEXT_PATCH-alpha.N) — CI builds a GitHub pre-release, no Packagist ping"; \
+	printf "    %-12s %s\n" "make patch" "Bump patch version  ($$CURRENT → $$NEXT_PATCH)"; \
 	printf "    %-12s %s\n" "make minor" "Bump minor version  ($$CURRENT → v$$MAJOR.$$((MINOR+1)).0)"; \
 	printf "    %-12s %s\n" "make major" "Bump major version  ($$CURRENT → v$$((MAJOR+1)).0.0)"; \
 	echo ""
 
 current:
-	@git tag --sort=-version:refname --merged origin/main 2>/dev/null | head -1 || echo "v0.0.0"
+	@git tag --sort=-version:refname --merged origin/main 2>/dev/null | grep -v -- '-' | head -1 || echo "v0.0.0"
 
 # ──────────────────────────────────────────────────────────────────────────────
 
 patch:
-	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | head -1); \
+	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | grep -v -- '-' | head -1); \
 	CURRENT=$${CURRENT:-v0.0.0}; \
 	VERSION=$$(echo "$$CURRENT" | sed 's/^v//'); \
 	MAJOR=$$(echo "$$VERSION" | cut -d. -f1); \
@@ -41,7 +46,7 @@ patch:
 	echo "Done — $$NEW pushed. CI will build the release automatically."
 
 minor:
-	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | head -1); \
+	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | grep -v -- '-' | head -1); \
 	CURRENT=$${CURRENT:-v0.0.0}; \
 	VERSION=$$(echo "$$CURRENT" | sed 's/^v//'); \
 	MAJOR=$$(echo "$$VERSION" | cut -d. -f1); \
@@ -53,7 +58,7 @@ minor:
 	echo "Done — $$NEW pushed. CI will build the release automatically."
 
 major:
-	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | head -1); \
+	@CURRENT=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | grep -v -- '-' | head -1); \
 	CURRENT=$${CURRENT:-v0.0.0}; \
 	VERSION=$$(echo "$$CURRENT" | sed 's/^v//'); \
 	MAJOR=$$(echo "$$VERSION" | cut -d. -f1); \
@@ -62,3 +67,24 @@ major:
 	git tag "$$NEW"; \
 	git push origin "$$NEW"; \
 	echo "Done — $$NEW pushed. CI will build the release automatically."
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Pre-release: tags the next patch version as v$NEXT_PATCH-alpha.N, where N
+# auto-increments based on existing alpha tags for that target. Marked as a
+# GitHub pre-release by CI; Packagist is NOT notified.
+# ──────────────────────────────────────────────────────────────────────────────
+
+alpha:
+	@STABLE=$$(git tag --sort=-version:refname --merged origin/main 2>/dev/null | grep -v -- '-' | head -1); \
+	STABLE=$${STABLE:-v0.0.0}; \
+	VERSION=$$(echo "$$STABLE" | sed 's/^v//'); \
+	MAJOR=$$(echo "$$VERSION" | cut -d. -f1); \
+	MINOR=$$(echo "$$VERSION" | cut -d. -f2); \
+	PATCH=$$(echo "$$VERSION" | cut -d. -f3); \
+	TARGET="v$$MAJOR.$$MINOR.$$((PATCH+1))"; \
+	COUNT=$$(git tag --list "$$TARGET-alpha.*" | wc -l | tr -d ' '); \
+	NEW="$$TARGET-alpha.$$((COUNT+1))"; \
+	echo "Tagging $$NEW..."; \
+	git tag "$$NEW"; \
+	git push origin "$$NEW"; \
+	echo "Done — $$NEW pushed. CI will build a pre-release automatically."


### PR DESCRIPTION
## Summary

Fixes the v0.6.7 release failure on all platforms:

> In DependencyUtil.php line 181:
> Library [oniguruma] not exist !

SPC 2.8.4 names the library `onig`, and it's pulled in via the separate `mbregex` extension (not `mbstring`, which is a builtin with no lib-depends). Adding `mbregex` to the extensions list lets SPC auto-resolve `onig` via its lib-depends, so the explicit `EXTRA_LIBS=oniguruma` workaround is removed.

Also adds a dry-run + pre-release path so CI changes can be verified before cutting a stable tag.

## What changed

**Fix (`.github/workflows/build.yml`)**
- `EXTENSIONS` now includes `mbregex`
- `EXTRA_LIBS` env removed; `--for-libs` / `--with-libs` no longer append it
- Cache keys bumped from `-oniguruma-v6` → `-mbregex-v1` to avoid stale hits

**Test-release tooling**
- `workflow_dispatch` trigger: runs test + build + artifact upload, skips release + packagist. VERSION stamps as `dev-<shortsha>` on manual runs.
- Tags matching `-alpha` / `-beta` / `-rc` → published as GitHub pre-releases, Packagist not notified.
- `make alpha` tags `v<next-patch>-alpha.N` with auto-incrementing N. `patch`/`minor`/`major`/`current` now filter pre-release tags when finding the latest stable.

## Test plan

- [ ] Trigger **Actions → build → Run workflow** on this branch and confirm all three binaries build + smoke-test pass (dry-run, no release created)
- [ ] After merge, tag `make alpha` and confirm CI publishes a pre-release, Packagist is not pinged
- [ ] Tag `make patch` (or continue normal flow) and confirm the stable release path still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)