### PR TITLE
fix(ci): create releases as drafts to work around immutable-release uploads

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -356,10 +356,14 @@ jobs:
           path: ./artifacts
           merge-multiple: true
 
-      - name: Create GitHub Release
+      # Two-step publish: create as draft so assets can be uploaded, then flip to
+      # published. Repo has immutable releases enabled — once a non-draft release
+      # exists, GitHub rejects further asset uploads. A draft is mutable.
+      - name: Create draft GitHub Release with assets
         uses: softprops/action-gh-release@v3
         with:
           files: ./artifacts/*
+          draft: true
           # Tags like v0.6.8-alpha.1 / -beta.1 / -rc.1 are marked as pre-release.
           prerelease: ${{ contains(github.ref_name, '-alpha') || contains(github.ref_name, '-beta') || contains(github.ref_name, '-rc') }}
           body: |
@@ -421,6 +425,11 @@ jobs:
             composer require --dev clonio-dev/clonio-cli
             vendor/bin/clonio --version
             ```
+
+      - name: Publish the draft
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release edit "${{ github.ref_name }}" --draft=false
 
   notify-packagist:
     name: Notify Packagist


### PR DESCRIPTION
## Summary

Fixes release publishing after enabling **immutable releases** on the repo. Without this change, `make alpha` (and any future `make patch`) fail with:

> Error: Cannot upload asset clonio.phar to an immutable release.

softprops/action-gh-release creates the release and then uploads assets one by one. Once a non-draft release exists, the immutable-release setting rejects further asset uploads. A **draft** release is mutable, so the fix is the standard GitHub-recommended pattern: create as draft → upload assets → publish.

## Change

One release step → two:

1. `softprops/action-gh-release@v3` with `draft: true` — creates the release, uploads all assets to the draft. `prerelease:` is set on the draft and carried through to publish.
2. New step `gh release edit "$TAG" --draft=false` — flips the draft to published.

Works for both stable and pre-release tags.

## Cleanup to do after merging

The failed `v0.7.1-alpha.1` release exists on GitHub with no assets (draft=false, tag present). After merging this PR, to retry the alpha release:

```bash
gh release delete v0.7.1-alpha.1 --yes --repo clonio-dev/clonio-cli
git push --delete origin v0.7.1-alpha.1
git tag -d v0.7.1-alpha.1
make alpha   # tags v0.7.1-alpha.2 and pushes
```

Or if you'd rather reuse the same alpha number:
```bash
gh release delete v0.7.1-alpha.1 --yes --repo clonio-dev/clonio-cli
git push --delete origin v0.7.1-alpha.1
git push origin v0.7.1-alpha.1   # re-push the local tag
```

## Test plan

- [ ] Merge, then retag a pre-release (e.g. `make alpha`). Expect: draft created → 4 assets uploaded → release flipped to published → Docker image built and pushed.
- [ ] Next stable `make patch` publishes cleanly with same flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)