### PR TITLE
fix(ci): restrict release artifact download to binaries + phar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -373,6 +373,8 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: ./artifacts
+          # Explicit allowlist — excludes Docker Buildx summary artifacts and spc-logs-* from failed attempts.
+          pattern: '{clonio-linux-*,clonio-macos-*,clonio.phar}'
           merge-multiple: true
 
       # Two-step publish: create as draft so assets can be uploaded, then flip to


### PR DESCRIPTION
## Summary

- The release job's `actions/download-artifact@v8` had no pattern, so it tried to pull every artifact produced by the run.
- In v0.7.2 that list included the two `*.dockerbuild` summary artifacts from `docker/build-push-action@v6` (one per call — smoke-test build + publish build) and, after the aarch64 rerun, one `spc-logs-clonio-linux-aarch64` from the failed attempt.
- The two `.dockerbuild` downloads hit a transient Azure blob storage failure and took the whole release step down after 5 retries.
- Even on success, those files would have been attached as release assets by `softprops/action-gh-release@v3` (`files: ./artifacts/*`).

Fix: add an explicit allowlist pattern `{clonio-linux-*,clonio-macos-*,clonio.phar}` so the release step only sees the 4 intended release artifacts. Matches exactly the 3 binaries + PHAR; excludes `clonio-dev~clonio-cli~*.dockerbuild` and `spc-logs-*`.

## Test plan

- [x] v0.7.2 publish was manually unblocked by deleting the 3 extraneous artifacts from run 24790901370 and rerunning the failed job — confirms the artifacts were the only blocker.
- [ ] Next tag release (`v0.7.3` or later) runs the full pipeline with the pattern filter and produces a clean release with exactly 4 assets, even if `.dockerbuild` / `spc-logs-*` artifacts exist in the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)