### PR TITLE
feat(cloning): auto-bounds for key remapping (drop user range knobs)

### DIFF
--- a/.github/cloning-test/test.cloning.yaml
+++ b/.github/cloning-test/test.cloning.yaml
@@ -60,8 +60,6 @@ key_remapping:
     - table: users
       primary_key: id
       strategy: new_uuid
-      range_min: 1
-      range_max: 999999
       foreign_keys:
         - table: orders
           column: user_id

--- a/app/Commands/Cloning/DumpCommand.php
+++ b/app/Commands/Cloning/DumpCommand.php
@@ -353,8 +353,6 @@ class DumpCommand extends Command
                 table: $tableName,
                 primaryKey: $primaryKey,
                 strategy: KeyRemappingStrategy::RandomInteger,
-                rangeMin: 100000,
-                rangeMax: 9999999,
                 foreignKeys: $fksByReferencedTable[$tableName] ?? [],
             );
         }

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -326,7 +326,7 @@ class RunCommand extends Command
             try {
                 $counts = $step->run(
                     'Generating key mappings',
-                    fn (): array => $keyRemappingService->generateMappings($keyRemappingConfig, $sourceConnection, $sortedForMapping),
+                    fn (): array => $keyRemappingService->generateMappings($keyRemappingConfig, $sourceConnection, $sourceSchema, $sortedForMapping),
                 );
             } catch (Throwable $throwable) {
                 if (str_contains($throwable->getMessage(), 'Allowed memory size') || str_contains($throwable->getMessage(), 'Out of memory')) {

--- a/app/Data/Cloning/ColumnCloningConfigData.php
+++ b/app/Data/Cloning/ColumnCloningConfigData.php
@@ -22,8 +22,6 @@ final readonly class ColumnCloningConfigData
         public ?bool $preserveFormat,
         public ?string $staticValue,
         public ?string $remappingUse = null,
-        public ?int $remappingMin = null,
-        public ?int $remappingMax = null,
         public ?array $remappingForeignKeys = null,
     ) {}
 }

--- a/app/Data/Cloning/KeyRemappingTableData.php
+++ b/app/Data/Cloning/KeyRemappingTableData.php
@@ -13,8 +13,6 @@ final readonly class KeyRemappingTableData
         public string $table,
         public string $primaryKey,
         public KeyRemappingStrategy $strategy,
-        public int $rangeMin,
-        public int $rangeMax,
         public array $foreignKeys,
     ) {}
 }

--- a/app/Data/Schema/ColumnSchemaData.php
+++ b/app/Data/Schema/ColumnSchemaData.php
@@ -12,5 +12,6 @@ final readonly class ColumnSchemaData
         public bool $nullable,
         public ?string $default,
         public bool $isPrimary,
+        public bool $unsigned = false,
     ) {}
 }

--- a/app/Exceptions/KeyRemappingExhaustedException.php
+++ b/app/Exceptions/KeyRemappingExhaustedException.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class KeyRemappingExhaustedException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $table,
+        public readonly string $column,
+        public readonly string $columnType,
+        public readonly bool $unsigned,
+        public readonly int $typeMax,
+        public readonly int $rowCount,
+        public readonly int $upperSlots,
+        public readonly int $gapSlots,
+    ) {
+        parent::__construct(sprintf(
+            "Cannot remap table '%s': column '%s' is %s (%s, ceiling %d); %d rows requested, only %d slots available (%d above MAX(id), %d gaps below).",
+            $table,
+            $column,
+            strtoupper($columnType),
+            $unsigned ? 'unsigned' : 'signed',
+            $typeMax,
+            $rowCount,
+            $upperSlots + $gapSlots,
+            $upperSlots,
+            $gapSlots,
+        ));
+    }
+}

--- a/app/Exceptions/UnsupportedKeyColumnTypeException.php
+++ b/app/Exceptions/UnsupportedKeyColumnTypeException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class UnsupportedKeyColumnTypeException extends RuntimeException {}

--- a/app/Services/Cloning/CloningYamlLoader.php
+++ b/app/Services/Cloning/CloningYamlLoader.php
@@ -96,8 +96,6 @@ class CloningYamlLoader
                     table: $tableData->tableName,
                     primaryKey: $column->columnName,
                     strategy: KeyRemappingStrategy::tryFrom($column->remappingUse ?? 'random_integer') ?? KeyRemappingStrategy::RandomInteger,
-                    rangeMin: $column->remappingMin ?? 100000,
-                    rangeMax: $column->remappingMax ?? 9999999,
                     foreignKeys: $column->remappingForeignKeys ?? [],
                 );
             }
@@ -206,8 +204,6 @@ class CloningYamlLoader
             $primaryKey = is_string($tableEntry['primary_key'] ?? null) ? $tableEntry['primary_key'] : '';
             $strategyRaw = is_string($tableEntry['strategy'] ?? null) ? $tableEntry['strategy'] : 'random_integer';
             $strategy = KeyRemappingStrategy::tryFrom($strategyRaw) ?? KeyRemappingStrategy::RandomInteger;
-            $rangeMin = is_int($tableEntry['range_min'] ?? null) ? $tableEntry['range_min'] : 100000;
-            $rangeMax = is_int($tableEntry['range_max'] ?? null) ? $tableEntry['range_max'] : 9999999;
 
             $fks = [];
             $fksRaw = $tableEntry['foreign_keys'] ?? [];
@@ -238,8 +234,6 @@ class CloningYamlLoader
                 table: $table,
                 primaryKey: $primaryKey,
                 strategy: $strategy,
-                rangeMin: $rangeMin,
-                rangeMax: $rangeMax,
                 foreignKeys: $fks,
             );
         }
@@ -267,8 +261,6 @@ class CloningYamlLoader
         $preserveFormat = null;
         $staticValue = null;
         $remappingUse = null;
-        $remappingMin = null;
-        $remappingMax = null;
         $remappingForeignKeys = null;
 
         switch ($strategy) {
@@ -311,14 +303,6 @@ class CloningYamlLoader
                                     $remappingUse = is_string($argValue) ? $argValue : null;
                                     break;
 
-                                case 'min':
-                                    $remappingMin = is_int($argValue) ? $argValue : null;
-                                    break;
-
-                                case 'max':
-                                    $remappingMax = is_int($argValue) ? $argValue : null;
-                                    break;
-
                                 case 'foreign_keys':
                                     if (is_array($argValue)) {
                                         $remappingForeignKeys = [];
@@ -359,8 +343,6 @@ class CloningYamlLoader
             preserveFormat: $preserveFormat,
             staticValue: $staticValue,
             remappingUse: $remappingUse,
-            remappingMin: $remappingMin,
-            remappingMax: $remappingMax,
             remappingForeignKeys: $remappingForeignKeys,
         );
     }

--- a/app/Services/Cloning/CloningYamlValidator.php
+++ b/app/Services/Cloning/CloningYamlValidator.php
@@ -315,19 +315,13 @@ class CloningYamlValidator
                 $errors[] = sprintf("%s: 'strategy' must be one of: %s", $prefix, implode(', ', $validStrategies));
             }
 
-            if (($strategy ?? '') === 'random_integer') {
-                $rangeMin = $entry['range_min'] ?? 100000;
-                $rangeMax = $entry['range_max'] ?? 9999999;
-                if (! is_int($rangeMin) || $rangeMin < 1) {
-                    $errors[] = sprintf("%s: 'range_min' must be an integer >= 1", $prefix);
-                }
-
-                if (! is_int($rangeMax) || $rangeMax < 1) {
-                    $errors[] = sprintf("%s: 'range_max' must be an integer >= 1", $prefix);
-                }
-
-                if (is_int($rangeMin) && is_int($rangeMax) && $rangeMin >= $rangeMax) {
-                    $errors[] = sprintf("%s: 'range_min' must be less than 'range_max'", $prefix);
+            foreach (['range_min', 'range_max'] as $legacyKey) {
+                if (array_key_exists($legacyKey, $entry)) {
+                    $errors[] = sprintf(
+                        "%s: '%s' is no longer supported (auto-bounds is computed from column type — remove this line)",
+                        $prefix,
+                        $legacyKey,
+                    );
                 }
             }
 
@@ -440,29 +434,22 @@ class CloningYamlValidator
                     }
                 }
 
+                foreach (['min', 'max'] as $legacyKey) {
+                    if (array_key_exists($legacyKey, $args)) {
+                        $errors[] = sprintf(
+                            "%s: 'remapping' argument '%s' is no longer supported (auto-bounds is computed from column type — remove this line)",
+                            $prefix,
+                            $legacyKey,
+                        );
+                    }
+                }
+
                 $validUseValues = ['random_integer', 'new_uuid'];
                 $use = $args['use'] ?? null;
 
                 if (! is_string($use) || ! in_array($use, $validUseValues, true)) {
                     $errors[] = sprintf("%s: 'remapping' requires argument 'use' (one of: %s)", $prefix, implode(', ', $validUseValues));
                     break;
-                }
-
-                if ($use === 'random_integer') {
-                    $min = $args['min'] ?? null;
-                    $max = $args['max'] ?? null;
-
-                    if (! is_int($min) || $min < 1) {
-                        $errors[] = sprintf("%s: 'remapping' requires argument 'min' (integer >= 1)", $prefix);
-                    }
-
-                    if (! is_int($max) || $max < 1) {
-                        $errors[] = sprintf("%s: 'remapping' requires argument 'max' (integer >= 1)", $prefix);
-                    }
-
-                    if (is_int($min) && is_int($max) && $min >= $max) {
-                        $errors[] = sprintf("%s: 'remapping' argument 'min' must be less than 'max'", $prefix);
-                    }
                 }
 
                 break;

--- a/app/Services/Cloning/CloningYamlWriter.php
+++ b/app/Services/Cloning/CloningYamlWriter.php
@@ -8,7 +8,6 @@ use App\Data\Cloning\ColumnDumpData;
 use App\Data\Cloning\DumpResultData;
 use App\Data\Cloning\KeyRemappingForeignKeyData;
 use App\Data\Cloning\KeyRemappingTableData;
-use App\Enums\KeyRemappingStrategy;
 use Illuminate\Support\Facades\Storage;
 
 class CloningYamlWriter
@@ -74,11 +73,6 @@ class CloningYamlWriter
                     $lines[] = '        strategy: remapping';
                     $lines[] = '        arguments:';
                     $lines[] = sprintf('          - use: %s', $krTable->strategy->value);
-
-                    if ($krTable->strategy === KeyRemappingStrategy::RandomInteger) {
-                        $lines[] = sprintf('          - min: %d', $krTable->rangeMin);
-                        $lines[] = sprintf('          - max: %d', $krTable->rangeMax);
-                    }
 
                     if ($krTable->foreignKeys !== []) {
                         $fkYaml = array_map(

--- a/app/Services/Cloning/KeyRemappingService.php
+++ b/app/Services/Cloning/KeyRemappingService.php
@@ -7,18 +7,22 @@ namespace App\Services\Cloning;
 use App\Data\Cloning\KeyRemappingConfigData;
 use App\Data\Cloning\KeyRemappingTableData;
 use App\Data\ConnectionData;
+use App\Data\Schema\ColumnSchemaData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\TableSchemaData;
 use App\Enums\KeyRemappingStrategy;
+use App\Exceptions\KeyRemappingExhaustedException;
 use App\Services\Database\DatabaseConnectionService;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use RuntimeException;
-use Throwable;
 
 class KeyRemappingService
 {
     public function __construct(
         private readonly DatabaseConnectionService $connector,
         private readonly KeyRemappingStoreInterface $store = new InMemoryKeyRemappingStore,
+        private readonly KeyTypeBoundsResolver $boundsResolver = new KeyTypeBoundsResolver,
     ) {}
 
     /**
@@ -31,6 +35,7 @@ class KeyRemappingService
     public function generateMappings(
         KeyRemappingConfigData $config,
         ConnectionData $source,
+        DatabaseSchemaData $sourceSchema,
         array $orderedTables,
     ): array {
         $counts = [];
@@ -41,17 +46,101 @@ class KeyRemappingService
                 continue;
             }
 
-            $counts[$tableName] = $this->generateTableMapping($tableConfig, $source);
+            $counts[$tableName] = $this->generateTableMapping($tableConfig, $source, $sourceSchema);
         }
 
         return $counts;
     }
 
     /**
-     * @return int Number of rows mapped
+     * Pure allocator: returns oldId(string) => newId(string), preserving source order.
+     *
+     * @param  list<string>  $sourceIds  Stringified PK values from the source table.
+     * @param  list<int>  $existingIds  Numeric PK values cast to int (used for gap-fill fallback).
+     * @return array<string, string>
      */
-    private function generateTableMapping(KeyRemappingTableData $config, ConnectionData $source): int
+    public function allocateIntegerIds(
+        string $table,
+        ColumnSchemaData $column,
+        array $sourceIds,
+        int $existingMax,
+        array $existingIds,
+    ): array {
+        $rowCount = count($sourceIds);
+        if ($rowCount === 0) {
+            return [];
+        }
+
+        $typeMax = $this->boundsResolver->ceilingFor($column);
+        $upperStart = max($existingMax + 1, 1);
+        $upperSlots = $upperStart > $typeMax ? 0 : ($typeMax - $upperStart + 1);
+
+        $targets = [];
+
+        if ($upperSlots >= $rowCount) {
+            for ($i = 0; $i < $rowCount; $i++) {
+                $targets[] = $upperStart + $i;
+            }
+        } else {
+            for ($i = 0; $i < $upperSlots; $i++) {
+                $targets[] = $upperStart + $i;
+            }
+
+            $needed = $rowCount - $upperSlots;
+            $gaps = $this->findGaps($existingIds, 1, $existingMax);
+
+            if (count($gaps) < $needed) {
+                throw new KeyRemappingExhaustedException(
+                    table: $table,
+                    column: $column->name,
+                    columnType: $column->type,
+                    unsigned: $column->unsigned,
+                    typeMax: $typeMax,
+                    rowCount: $rowCount,
+                    upperSlots: $upperSlots,
+                    gapSlots: count($gaps),
+                );
+            }
+
+            for ($i = 0; $i < $needed; $i++) {
+                $targets[] = $gaps[$i];
+            }
+        }
+
+        $mapping = [];
+        foreach ($sourceIds as $i => $oldId) {
+            $mapping[$oldId] = (string) $targets[$i];
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * @param  list<int>  $existingIds
+     * @return list<int>
+     */
+    private function findGaps(array $existingIds, int $lo, int $hi): array
     {
+        if ($hi < $lo) {
+            return [];
+        }
+
+        $set = array_flip($existingIds);
+        $gaps = [];
+        for ($i = $lo; $i <= $hi; $i++) {
+            if (! isset($set[$i])) {
+                $gaps[] = $i;
+            }
+        }
+
+        return $gaps;
+    }
+
+    private function generateTableMapping(
+        KeyRemappingTableData $config,
+        ConnectionData $source,
+        DatabaseSchemaData $sourceSchema,
+    ): int {
         $connName = $this->connector->open($source);
         $pkCol = $config->primaryKey;
         $table = $config->table;
@@ -74,64 +163,67 @@ class KeyRemappingService
                 sprintf('SELECT %s FROM %s', $quotedCol, $quotedTable)
             );
 
-            /** @var array<string, string> $tableMappings */
-            $tableMappings = [];
-            $usedIntegers = [];
-
+            $sourceIds = [];
+            $existingIdsInt = [];
             foreach ($rows as $row) {
                 $rowArray = (array) $row;
                 $rawValue = $rowArray[$pkCol] ?? null;
                 $oldValue = is_scalar($rawValue) ? (string) $rawValue : '';
-
-                $newValue = match ($config->strategy) {
-                    KeyRemappingStrategy::NewUuid => (string) Str::uuid(),
-                    KeyRemappingStrategy::RandomInteger => $this->generateUniqueInteger(
-                        $config->rangeMin,
-                        $config->rangeMax,
-                        $usedIntegers,
-                        $table,
-                    ),
-                };
-
-                $tableMappings[$oldValue] = $newValue;
+                $sourceIds[] = $oldValue;
+                if (is_numeric($oldValue)) {
+                    $existingIdsInt[] = (int) $oldValue;
+                }
             }
+
+            $existingMax = $existingIdsInt === [] ? 0 : max($existingIdsInt);
+
+            $tableMappings = match ($config->strategy) {
+                KeyRemappingStrategy::NewUuid => $this->allocateUuids($sourceIds),
+                KeyRemappingStrategy::RandomInteger => $this->allocateIntegerIds(
+                    $table,
+                    $this->resolvePkColumn($sourceSchema, $table, $pkCol),
+                    $sourceIds,
+                    $existingMax,
+                    $existingIdsInt,
+                ),
+            };
 
             $this->store->storeTable($table, $tableMappings);
 
             return count($tableMappings);
-        } catch (Throwable) {
-            return 0;
         } finally {
             DB::purge($connName);
         }
     }
 
     /**
-     * @param  array<int, true>  $used
+     * @param  list<string>  $sourceIds
+     * @return array<string, string>
      */
-    private function generateUniqueInteger(int $min, int $max, array &$used, string $table): string
+    private function allocateUuids(array $sourceIds): array
     {
-        $range = $max - $min;
-        if ($range < 1) {
-            throw new RuntimeException(
-                sprintf("Key remapping range for table '%s' is exhausted (min=%d, max=%d).", $table, $min, $max)
-            );
+        $mapping = [];
+        foreach ($sourceIds as $oldId) {
+            $mapping[$oldId] = (string) Str::uuid();
         }
 
-        $attempts = 0;
-        do {
-            $value = random_int($min, $max);
-            $attempts++;
-            if ($attempts > $range * 2 + 100) {
-                throw new RuntimeException(
-                    sprintf("Key remapping range exhausted for table '%s'. Increase range_min/range_max.", $table)
-                );
+        return $mapping;
+    }
+
+    private function resolvePkColumn(DatabaseSchemaData $schema, string $table, string $column): ColumnSchemaData
+    {
+        $tableSchema = $schema->getTable($table);
+        if (! $tableSchema instanceof TableSchemaData) {
+            throw new RuntimeException(sprintf("Table '%s' not found in source schema", $table));
+        }
+
+        foreach ($tableSchema->columns as $col) {
+            if ($col->name === $column) {
+                return $col;
             }
-        } while (isset($used[$value]));
+        }
 
-        $used[$value] = true;
-
-        return (string) $value;
+        throw new RuntimeException(sprintf("Primary key column '%s' not found on table '%s' in source schema", $column, $table));
     }
 
     /**

--- a/app/Services/Cloning/KeyTypeBoundsResolver.php
+++ b/app/Services/Cloning/KeyTypeBoundsResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cloning;
+
+use App\Data\Schema\ColumnSchemaData;
+use App\Exceptions\UnsupportedKeyColumnTypeException;
+
+final class KeyTypeBoundsResolver
+{
+    public function ceilingFor(ColumnSchemaData $column): int
+    {
+        $type = strtolower($column->type);
+
+        return match ($type) {
+            'tinyint' => $column->unsigned ? 255 : 127,
+            'smallint' => $column->unsigned ? 65535 : 32767,
+            'mediumint' => $column->unsigned ? 16777215 : 8388607,
+            'int', 'integer' => $column->unsigned ? 4294967295 : 2147483647,
+            'bigint' => PHP_INT_MAX,
+            default => throw new UnsupportedKeyColumnTypeException(
+                sprintf("Column '%s' has type '%s' which is not supported for integer key remapping", $column->name, $column->type)
+            ),
+        };
+    }
+}

--- a/app/Services/Schema/SchemaInspector.php
+++ b/app/Services/Schema/SchemaInspector.php
@@ -58,7 +58,7 @@ class SchemaInspector
 
             /** @var list<stdClass> $columnRows */
             $columnRows = DB::connection($connName)->select(
-                'SELECT COLUMN_NAME, DATA_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION',
+                'SELECT COLUMN_NAME, DATA_TYPE, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION',
                 [$tableName]
             );
 
@@ -69,6 +69,8 @@ class SchemaInspector
                 $colName = $col->COLUMN_NAME;
                 /** @var string $dataType */
                 $dataType = $col->DATA_TYPE;
+                /** @var string $columnType */
+                $columnType = $col->COLUMN_TYPE;
                 /** @var string $isNullable */
                 $isNullable = $col->IS_NULLABLE;
                 $rawDefault = $col->COLUMN_DEFAULT ?? null;
@@ -82,6 +84,7 @@ class SchemaInspector
                     nullable: $isNullable === 'YES',
                     default: $colDefault,
                     isPrimary: $colKey === 'PRI',
+                    unsigned: str_contains(strtolower($columnType), 'unsigned'),
                 );
             }
 

--- a/docs/cloning-yaml.md
+++ b/docs/cloning-yaml.md
@@ -268,8 +268,6 @@ id:
   strategy: remapping
   arguments:
     - use: random_integer
-    - min: 100000
-    - max: 9999999
     - foreign_keys:
         - table: orders
           column: user_id
@@ -450,8 +448,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: orders
                 column: user_id
@@ -495,8 +491,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: order_items
                 column: order_id

--- a/docs/commands/cloning-run.md
+++ b/docs/commands/cloning-run.md
@@ -213,8 +213,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: orders
                 column: user_id
@@ -234,8 +232,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: order_items
                 column: order_id
@@ -254,8 +250,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: employees
                 column: manager_id

--- a/docs/superpowers/plans/2026-04-27-key-remapping-auto-bounds.md
+++ b/docs/superpowers/plans/2026-04-27-key-remapping-auto-bounds.md
@@ -1,0 +1,1128 @@
+# Key Remapping Auto-Bounds Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace user-configured key-remapping ranges with type-aware automatic ID allocation (`MAX(id)+1` ascending, gap-fill fallback) so PK collisions on narrow column types (e.g. `SMALLINT UNSIGNED`) become impossible.
+
+**Architecture:** A new `KeyTypeBoundsResolver` derives the integer ceiling from `ColumnSchemaData.type` + a new `unsigned` flag populated by `SchemaInspector`. `KeyRemappingService::generateTableMapping` reads `MAX(id)` from the source PK, allocates `[MAX(id)+1, typeMax]` ascending, falls back to filling gaps in `[1, MAX(id)]`, and throws `KeyRemappingExhaustedException` if neither covers the row count. All `min`/`max`/`range_min`/`range_max` knobs are removed from DTOs, YAML loader, validator, writer, and `cloning:dump`. Pre-1.0.0 — no backward compat; legacy range keys produce hard validation errors.
+
+**Tech Stack:** PHP 8.5, Laravel Zero 12, Pest 4, PHPStan max, Larastan, Pint, Rector.
+
+---
+
+## File Structure
+
+**New files:**
+- `app/Services/Cloning/KeyTypeBoundsResolver.php` — pure helper: `ColumnSchemaData → int ceiling`
+- `app/Exceptions/KeyRemappingExhaustedException.php` — runtime, raised when no slots remain
+- `app/Exceptions/UnsupportedKeyColumnTypeException.php` — runtime, raised when column type is not an integer
+- `tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php`
+
+**Modified files:**
+- `app/Data/Schema/ColumnSchemaData.php` — add `bool $unsigned`
+- `app/Services/Schema/SchemaInspector.php` — read `COLUMN_TYPE` for MySQL/MariaDB, set `unsigned`
+- `app/Data/Cloning/KeyRemappingTableData.php` — drop `rangeMin`, `rangeMax`
+- `app/Data/Cloning/ColumnCloningConfigData.php` — drop `remappingMin`, `remappingMax`
+- `app/Services/Cloning/CloningYamlLoader.php` — drop range parsing (legacy + inline)
+- `app/Services/Cloning/CloningYamlValidator.php` — hard-error on `min`/`max`/`range_min`/`range_max`
+- `app/Services/Cloning/CloningYamlWriter.php` — stop emitting `- min:` / `- max:`
+- `app/Commands/Cloning/DumpCommand.php` — drop `rangeMin`/`rangeMax` ctor args
+- `app/Services/Cloning/KeyRemappingService.php` — accept `DatabaseSchemaData`, new strategy
+- `app/Commands/Cloning/RunCommand.php` — pass `$sourceSchema` into `generateMappings()`
+- `specs/PRD-cloning-key-remapping.md` — drop range refs, add auto-bounds section
+- `tests/Unit/Data/Cloning/KeyRemappingDtoTest.php` — drop range assertions
+- `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php` — drop range tests
+- `tests/Unit/Services/Cloning/CloningYamlValidatorTest.php` — replace range tests with rejection tests
+- `tests/Unit/Services/Cloning/CloningYamlWriterTest.php` — drop range emission expectations
+- `tests/Unit/Services/Cloning/KeyRemappingServiceTest.php` — new strategy tests
+
+---
+
+## Task 1: ColumnSchemaData.unsigned + SchemaInspector wiring
+
+**Files:**
+- Modify: `app/Data/Schema/ColumnSchemaData.php`
+- Modify: `app/Services/Schema/SchemaInspector.php` (MySQL branch around lines 60-86)
+- Test: existing inspector tests + a new MySQL-specific test (skipped if no MySQL fixture; covered indirectly by integration). For unit: add a `ColumnSchemaDataTest` field test.
+
+- [ ] **Step 1: Add field to DTO**
+
+```php
+// app/Data/Schema/ColumnSchemaData.php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Schema;
+
+final readonly class ColumnSchemaData
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public bool $nullable,
+        public ?string $default,
+        public bool $isPrimary,
+        public bool $unsigned = false,
+    ) {}
+}
+```
+
+- [ ] **Step 2: Inspector reads COLUMN_TYPE for MySQL**
+
+Modify the SQL on lines 60-63 of `app/Services/Schema/SchemaInspector.php` to also select `COLUMN_TYPE`, and propagate the `unsigned` flag at the `ColumnSchemaData` construction (around line 79):
+
+```php
+/** @var list<stdClass> $columnRows */
+$columnRows = DB::connection($connName)->select(
+    'SELECT COLUMN_NAME, DATA_TYPE, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT, COLUMN_KEY FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? ORDER BY ORDINAL_POSITION',
+    [$tableName]
+);
+
+$columns = [];
+
+foreach ($columnRows as $col) {
+    /** @var string $colName */
+    $colName = $col->COLUMN_NAME;
+    /** @var string $dataType */
+    $dataType = $col->DATA_TYPE;
+    /** @var string $columnType */
+    $columnType = $col->COLUMN_TYPE;
+    /** @var string $isNullable */
+    $isNullable = $col->IS_NULLABLE;
+    $rawDefault = $col->COLUMN_DEFAULT ?? null;
+    $colDefault = is_scalar($rawDefault) ? (string) $rawDefault : null;
+    /** @var string $colKey */
+    $colKey = $col->COLUMN_KEY;
+
+    $columns[] = new ColumnSchemaData(
+        name: $colName,
+        type: $dataType,
+        nullable: $isNullable === 'YES',
+        default: $colDefault,
+        isPrimary: $colKey === 'PRI',
+        unsigned: str_contains(strtolower($columnType), 'unsigned'),
+    );
+}
+```
+
+Postgres, SQLite, SQL Server branches: leave the constructor calls as-is — they will pick up the default `unsigned: false`.
+
+- [ ] **Step 3: Run existing tests to confirm nothing broke**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Schema --no-coverage`
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add app/Data/Schema/ColumnSchemaData.php app/Services/Schema/SchemaInspector.php
+git commit -m "feat(schema): add unsigned flag to ColumnSchemaData (MySQL/MariaDB)"
+```
+
+---
+
+## Task 2: KeyTypeBoundsResolver + UnsupportedKeyColumnTypeException
+
+**Files:**
+- Create: `app/Exceptions/UnsupportedKeyColumnTypeException.php`
+- Create: `app/Services/Cloning/KeyTypeBoundsResolver.php`
+- Test: `tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php`
+
+- [ ] **Step 1: Write failing test**
+
+```php
+// tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php
+<?php
+
+declare(strict_types=1);
+
+use App\Data\Schema\ColumnSchemaData;
+use App\Exceptions\UnsupportedKeyColumnTypeException;
+use App\Services\Cloning\KeyTypeBoundsResolver;
+
+function makeIntCol(string $type, bool $unsigned = false): ColumnSchemaData
+{
+    return new ColumnSchemaData(
+        name: 'id',
+        type: $type,
+        nullable: false,
+        default: null,
+        isPrimary: true,
+        unsigned: $unsigned,
+    );
+}
+
+it('returns 127 for signed tinyint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('tinyint')))->toBe(127);
+});
+
+it('returns 255 for unsigned tinyint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('tinyint', true)))->toBe(255);
+});
+
+it('returns 32767 for signed smallint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('smallint')))->toBe(32767);
+});
+
+it('returns 65535 for unsigned smallint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('smallint', true)))->toBe(65535);
+});
+
+it('returns 8388607 for signed mediumint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('mediumint')))->toBe(8388607);
+});
+
+it('returns 16777215 for unsigned mediumint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('mediumint', true)))->toBe(16777215);
+});
+
+it('returns 2147483647 for signed int', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('int')))->toBe(2147483647);
+});
+
+it('returns 4294967295 for unsigned int', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('int', true)))->toBe(4294967295);
+});
+
+it('treats integer alias same as int', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('integer')))->toBe(2147483647);
+});
+
+it('returns PHP_INT_MAX for bigint regardless of signedness', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('bigint')))->toBe(PHP_INT_MAX)
+        ->and((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('bigint', true)))->toBe(PHP_INT_MAX);
+});
+
+it('is case-insensitive on type name', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('INT', true)))->toBe(4294967295);
+});
+
+it('throws UnsupportedKeyColumnTypeException for non-integer types', function (): void {
+    (new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('varchar'));
+})->throws(UnsupportedKeyColumnTypeException::class);
+
+it('throws UnsupportedKeyColumnTypeException for char (UUID columns must use new_uuid)', function (): void {
+    (new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('char'));
+})->throws(UnsupportedKeyColumnTypeException::class);
+```
+
+- [ ] **Step 2: Run test, confirm fail**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php --no-coverage`
+Expected: FAIL — class not found.
+
+- [ ] **Step 3: Implement exception**
+
+```php
+// app/Exceptions/UnsupportedKeyColumnTypeException.php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class UnsupportedKeyColumnTypeException extends RuntimeException {}
+```
+
+- [ ] **Step 4: Implement resolver**
+
+```php
+// app/Services/Cloning/KeyTypeBoundsResolver.php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cloning;
+
+use App\Data\Schema\ColumnSchemaData;
+use App\Exceptions\UnsupportedKeyColumnTypeException;
+
+final class KeyTypeBoundsResolver
+{
+    public function ceilingFor(ColumnSchemaData $column): int
+    {
+        $type = strtolower($column->type);
+
+        return match ($type) {
+            'tinyint' => $column->unsigned ? 255 : 127,
+            'smallint' => $column->unsigned ? 65535 : 32767,
+            'mediumint' => $column->unsigned ? 16777215 : 8388607,
+            'int', 'integer' => $column->unsigned ? 4294967295 : 2147483647,
+            'bigint' => PHP_INT_MAX,
+            default => throw new UnsupportedKeyColumnTypeException(
+                sprintf("Column '%s' has type '%s' which is not supported for integer key remapping", $column->name, $column->type)
+            ),
+        };
+    }
+}
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php --no-coverage`
+Expected: 12 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add app/Services/Cloning/KeyTypeBoundsResolver.php app/Exceptions/UnsupportedKeyColumnTypeException.php tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php
+git commit -m "feat(cloning): add KeyTypeBoundsResolver for type-aware integer ceilings"
+```
+
+---
+
+## Task 3: KeyRemappingExhaustedException
+
+**Files:**
+- Create: `app/Exceptions/KeyRemappingExhaustedException.php`
+
+- [ ] **Step 1: Implement exception**
+
+```php
+// app/Exceptions/KeyRemappingExhaustedException.php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+use RuntimeException;
+
+final class KeyRemappingExhaustedException extends RuntimeException
+{
+    public function __construct(
+        public readonly string $table,
+        public readonly string $column,
+        public readonly string $columnType,
+        public readonly bool $unsigned,
+        public readonly int $typeMax,
+        public readonly int $rowCount,
+        public readonly int $upperSlots,
+        public readonly int $gapSlots,
+    ) {
+        parent::__construct(sprintf(
+            "Cannot remap table '%s': column '%s' is %s (%s, ceiling %d); %d rows requested, only %d slots available (%d above MAX(id), %d gaps below).",
+            $table,
+            $column,
+            strtoupper($columnType),
+            $unsigned ? 'unsigned' : 'signed',
+            $typeMax,
+            $rowCount,
+            $upperSlots + $gapSlots,
+            $upperSlots,
+            $gapSlots,
+        ));
+    }
+}
+```
+
+- [ ] **Step 2: Commit (combined with Task 4 commit, no separate commit)**
+
+(No standalone commit — exception is exercised by Task 4 tests.)
+
+---
+
+## Task 4: Rewrite KeyRemappingService for type-aware allocation
+
+**Files:**
+- Modify: `app/Services/Cloning/KeyRemappingService.php`
+- Modify: `tests/Unit/Services/Cloning/KeyRemappingServiceTest.php`
+
+We can't easily unit-test `generateTableMapping` end-to-end without real DB access (it issues `SELECT` queries via `DB::connection`). So we extract the pure allocation logic into a method that takes the source IDs as input, and write unit tests against that method. The DB-fetching wrapper stays thin and is exercised by feature tests later (out of scope for this plan).
+
+- [ ] **Step 1: Write failing test for the pure allocator**
+
+```php
+// Add to tests/Unit/Services/Cloning/KeyRemappingServiceTest.php
+use App\Data\Schema\ColumnSchemaData;
+use App\Exceptions\KeyRemappingExhaustedException;
+
+function makePkCol(string $type, bool $unsigned = false): ColumnSchemaData
+{
+    return new ColumnSchemaData(
+        name: 'id',
+        type: $type,
+        nullable: false,
+        default: null,
+        isPrimary: true,
+        unsigned: $unsigned,
+    );
+}
+
+it('allocateIntegerIds returns ascending ids starting at MAX(id)+1', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('tinyint', true); // ceiling 255
+
+    $sourceIds = ['10', '20', '30', '40', '50'];
+    $existingMax = 200;
+
+    $result = $service->allocateIntegerIds('users', $col, $sourceIds, $existingMax, []);
+
+    expect(array_values($result))->toBe(['201', '202', '203', '204', '205'])
+        ->and(array_keys($result))->toBe(['10', '20', '30', '40', '50']);
+});
+
+it('allocateIntegerIds falls back to gap-fill when upper region exhausted', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('tinyint', true); // ceiling 255
+
+    $sourceIds = ['1', '2', '3', '4', '5'];
+    $existingMax = 253;
+    $existingIds = [1, 2, 250, 251, 252, 253]; // gaps in [1,253] = [3..249] (lots of room)
+
+    $result = $service->allocateIntegerIds('users', $col, $sourceIds, $existingMax, $existingIds);
+
+    // upper slots: 255 - 254 + 1 = 2 → IDs 254, 255
+    // remaining 3: first 3 gaps = 3, 4, 5
+    expect(array_values($result))->toBe(['254', '255', '3', '4', '5']);
+});
+
+it('allocateIntegerIds throws when type ceiling cannot host row count', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('tinyint', true); // ceiling 255
+
+    $sourceIds = array_map(static fn (int $i): string => (string) $i, range(1, 300));
+    $existingMax = 0;
+    $existingIds = [];
+
+    $service->allocateIntegerIds('big_table', $col, $sourceIds, $existingMax, $existingIds);
+})->throws(KeyRemappingExhaustedException::class);
+
+it('allocateIntegerIds starts at 1 when source table is empty', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('int');
+
+    $result = $service->allocateIntegerIds('users', $col, ['7'], 0, []);
+
+    expect($result)->toBe(['7' => '1']);
+});
+
+it('allocateIntegerIds for signed int never returns negative ids', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('int'); // signed ceiling 2147483647
+
+    $result = $service->allocateIntegerIds('users', $col, ['1', '2'], 0, []);
+
+    expect(array_values($result))->toBe(['1', '2']);
+});
+
+it('allocateIntegerIds preserves source order when assigning new ids', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('int', true);
+
+    $sourceIds = ['100', '99', '500', '7'];
+
+    $result = $service->allocateIntegerIds('t', $col, $sourceIds, 1000, []);
+
+    expect($result)->toBe([
+        '100' => '1001',
+        '99' => '1002',
+        '500' => '1003',
+        '7' => '1004',
+    ]);
+});
+```
+
+Update the existing helper `makeKeyRemappingTable` so it no longer passes `rangeMin` / `rangeMax` (those args are removed in Task 5). For now, keep the helper as-is — Task 5 will fix it. After Task 5, the existing tests at lines 22-32, 86-94 must be updated to drop range args.
+
+- [ ] **Step 2: Run test, confirm fail**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Cloning/KeyRemappingServiceTest.php --no-coverage`
+Expected: FAIL — `allocateIntegerIds` does not exist on service.
+
+- [ ] **Step 3: Add allocator + restructure service**
+
+Replace `generateUniqueInteger` (lines 110-135) with the new `allocateIntegerIds` (public for testability) and rewrite `generateTableMapping` (lines 53-107) to call it after fetching source IDs and `MAX(id)`. The service signature for `generateMappings` gains a `DatabaseSchemaData` parameter.
+
+```php
+// app/Services/Cloning/KeyRemappingService.php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cloning;
+
+use App\Data\Cloning\KeyRemappingConfigData;
+use App\Data\Cloning\KeyRemappingTableData;
+use App\Data\ConnectionData;
+use App\Data\Schema\ColumnSchemaData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Enums\KeyRemappingStrategy;
+use App\Exceptions\KeyRemappingExhaustedException;
+use App\Services\Cloning\KeyTypeBoundsResolver;
+use App\Services\Database\DatabaseConnectionService;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+class KeyRemappingService
+{
+    public function __construct(
+        private readonly DatabaseConnectionService $connector,
+        private readonly KeyRemappingStoreInterface $store = new InMemoryKeyRemappingStore,
+        private readonly KeyTypeBoundsResolver $boundsResolver = new KeyTypeBoundsResolver,
+    ) {}
+
+    /**
+     * @param  list<string>  $orderedTables
+     * @return array<string, int>
+     */
+    public function generateMappings(
+        KeyRemappingConfigData $config,
+        ConnectionData $source,
+        DatabaseSchemaData $sourceSchema,
+        array $orderedTables,
+    ): array {
+        $counts = [];
+
+        foreach ($orderedTables as $tableName) {
+            $tableConfig = $config->getTable($tableName);
+            if (! $tableConfig instanceof KeyRemappingTableData) {
+                continue;
+            }
+
+            $counts[$tableName] = $this->generateTableMapping($tableConfig, $source, $sourceSchema);
+        }
+
+        return $counts;
+    }
+
+    /**
+     * Pure allocator. Returns oldId(string) => newId(string), preserving source order.
+     *
+     * @param  list<string>  $sourceIds
+     * @param  list<int>  $existingIds  Sorted or unsorted; will be deduped + sorted internally.
+     * @return array<string, string>
+     */
+    public function allocateIntegerIds(
+        string $table,
+        ColumnSchemaData $column,
+        array $sourceIds,
+        int $existingMax,
+        array $existingIds,
+    ): array {
+        $rowCount = count($sourceIds);
+        if ($rowCount === 0) {
+            return [];
+        }
+
+        $typeMax = $this->boundsResolver->ceilingFor($column);
+        $upperStart = max($existingMax + 1, 1);
+        $upperSlots = $upperStart > $typeMax ? 0 : ($typeMax - $upperStart + 1);
+
+        $targets = [];
+
+        if ($upperSlots >= $rowCount) {
+            for ($i = 0; $i < $rowCount; $i++) {
+                $targets[] = $upperStart + $i;
+            }
+        } else {
+            for ($i = 0; $i < $upperSlots; $i++) {
+                $targets[] = $upperStart + $i;
+            }
+
+            $needed = $rowCount - $upperSlots;
+            $gaps = $this->findGaps($existingIds, 1, $existingMax);
+
+            if (count($gaps) < $needed) {
+                throw new KeyRemappingExhaustedException(
+                    table: $table,
+                    column: $column->name,
+                    columnType: $column->type,
+                    unsigned: $column->unsigned,
+                    typeMax: $typeMax,
+                    rowCount: $rowCount,
+                    upperSlots: $upperSlots,
+                    gapSlots: count($gaps),
+                );
+            }
+
+            for ($i = 0; $i < $needed; $i++) {
+                $targets[] = $gaps[$i];
+            }
+        }
+
+        $mapping = [];
+        foreach ($sourceIds as $i => $oldId) {
+            $mapping[$oldId] = (string) $targets[$i];
+        }
+
+        return $mapping;
+    }
+
+    /**
+     * @param  list<int>  $existingIds
+     * @return list<int>
+     */
+    private function findGaps(array $existingIds, int $lo, int $hi): array
+    {
+        if ($hi < $lo) {
+            return [];
+        }
+
+        $set = array_flip($existingIds);
+        $gaps = [];
+        for ($i = $lo; $i <= $hi; $i++) {
+            if (! isset($set[$i])) {
+                $gaps[] = $i;
+            }
+        }
+
+        return $gaps;
+    }
+
+    private function generateTableMapping(
+        KeyRemappingTableData $config,
+        ConnectionData $source,
+        DatabaseSchemaData $sourceSchema,
+    ): int {
+        $connName = $this->connector->open($source);
+        $pkCol = $config->primaryKey;
+        $table = $config->table;
+
+        try {
+            $driver = $source->type->value;
+            $quotedTable = match ($driver) {
+                'mysql', 'mariadb' => '`'.$table.'`',
+                'sqlsrv' => '['.$table.']',
+                default => '"'.$table.'"',
+            };
+            $quotedCol = match ($driver) {
+                'mysql', 'mariadb' => '`'.$pkCol.'`',
+                'sqlsrv' => '['.$pkCol.']',
+                default => '"'.$pkCol.'"',
+            };
+
+            /** @var list<object> $rows */
+            $rows = DB::connection($connName)->select(
+                sprintf('SELECT %s FROM %s', $quotedCol, $quotedTable)
+            );
+
+            $sourceIds = [];
+            $existingIdsInt = [];
+            foreach ($rows as $row) {
+                $rowArray = (array) $row;
+                $rawValue = $rowArray[$pkCol] ?? null;
+                $oldValue = is_scalar($rawValue) ? (string) $rawValue : '';
+                $sourceIds[] = $oldValue;
+                if (is_numeric($oldValue)) {
+                    $existingIdsInt[] = (int) $oldValue;
+                }
+            }
+
+            $existingMax = $existingIdsInt === [] ? 0 : max($existingIdsInt);
+
+            $tableMappings = match ($config->strategy) {
+                KeyRemappingStrategy::NewUuid => $this->allocateUuids($sourceIds),
+                KeyRemappingStrategy::RandomInteger => $this->allocateIntegerIds(
+                    $table,
+                    $this->resolvePkColumn($sourceSchema, $table, $pkCol),
+                    $sourceIds,
+                    $existingMax,
+                    $existingIdsInt,
+                ),
+            };
+
+            $this->store->storeTable($table, $tableMappings);
+
+            return count($tableMappings);
+        } finally {
+            DB::purge($connName);
+        }
+    }
+
+    /**
+     * @param  list<string>  $sourceIds
+     * @return array<string, string>
+     */
+    private function allocateUuids(array $sourceIds): array
+    {
+        $mapping = [];
+        foreach ($sourceIds as $oldId) {
+            $mapping[$oldId] = (string) Str::uuid();
+        }
+
+        return $mapping;
+    }
+
+    private function resolvePkColumn(DatabaseSchemaData $schema, string $table, string $column): ColumnSchemaData
+    {
+        $tableSchema = $schema->getTable($table);
+        if ($tableSchema === null) {
+            throw new RuntimeException(sprintf("Table '%s' not found in source schema", $table));
+        }
+
+        foreach ($tableSchema->columns as $col) {
+            if ($col->name === $column) {
+                return $col;
+            }
+        }
+
+        throw new RuntimeException(sprintf("Primary key column '%s' not found on table '%s' in source schema", $column, $table));
+    }
+
+    /**
+     * Apply PK and FK remapping to a single row during transfer.
+     *
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    public function applyToRow(array $row, string $tableName, KeyRemappingConfigData $config): array
+    {
+        $tableConfig = $config->getTable($tableName);
+        if ($tableConfig instanceof KeyRemappingTableData) {
+            $pkCol = $tableConfig->primaryKey;
+            if (array_key_exists($pkCol, $row)) {
+                $rawPk = $row[$pkCol];
+                $oldPk = is_scalar($rawPk) ? (string) $rawPk : '';
+                $row[$pkCol] = $this->store->lookup($tableName, $oldPk) ?? $row[$pkCol];
+            }
+        }
+
+        foreach ($config->tables as $remappedTable) {
+            foreach ($remappedTable->foreignKeys as $fk) {
+                if ($fk->table !== $tableName) {
+                    continue;
+                }
+
+                if (! array_key_exists($fk->column, $row)) {
+                    continue;
+                }
+
+                $rawFk = $row[$fk->column];
+                $fkValue = is_scalar($rawFk) ? (string) $rawFk : '';
+                $row[$fk->column] = $this->store->lookup($remappedTable->table, $fkValue) ?? $row[$fk->column];
+            }
+        }
+
+        return $row;
+    }
+
+    public function cleanup(): void
+    {
+        $this->store->cleanup();
+    }
+}
+```
+
+Note: this introduces a behaviour change vs. the old code — the previous `generateTableMapping` swallowed all `Throwable` and returned 0. We drop that broad catch. Allocation errors must surface so the run fails loud (this is the entire point of the spec). The DB connection is still purged in `finally`.
+
+- [ ] **Step 4: Run tests, confirm new tests pass**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Cloning/KeyRemappingServiceTest.php --no-coverage`
+Expected: new allocator tests pass. Existing tests calling `makeKeyRemappingTable` may still pass (range args ignored) but will break in Task 5.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app/Exceptions/KeyRemappingExhaustedException.php app/Services/Cloning/KeyRemappingService.php tests/Unit/Services/Cloning/KeyRemappingServiceTest.php
+git commit -m "feat(cloning): rewrite key remapping for type-aware MAX(id)+1 allocation"
+```
+
+---
+
+## Task 5: Drop range fields from data layer
+
+**Files:**
+- Modify: `app/Data/Cloning/KeyRemappingTableData.php`
+- Modify: `app/Data/Cloning/ColumnCloningConfigData.php`
+- Modify: `tests/Unit/Data/Cloning/KeyRemappingDtoTest.php`
+
+- [ ] **Step 1: Update KeyRemappingTableData**
+
+```php
+// app/Data/Cloning/KeyRemappingTableData.php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Cloning;
+
+use App\Enums\KeyRemappingStrategy;
+
+final readonly class KeyRemappingTableData
+{
+    /** @param list<KeyRemappingForeignKeyData> $foreignKeys */
+    public function __construct(
+        public string $table,
+        public string $primaryKey,
+        public KeyRemappingStrategy $strategy,
+        public array $foreignKeys,
+    ) {}
+}
+```
+
+- [ ] **Step 2: Update ColumnCloningConfigData**
+
+```php
+// app/Data/Cloning/ColumnCloningConfigData.php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Cloning;
+
+final readonly class ColumnCloningConfigData
+{
+    /**
+     * @param  list<scalar>  $fakerArguments
+     * @param  list<KeyRemappingForeignKeyData>|null  $remappingForeignKeys
+     */
+    public function __construct(
+        public string $columnName,
+        public string $strategy,
+        public ?string $fakerMethod,
+        public array $fakerArguments,
+        public ?string $hashAlgorithm,
+        public ?string $hashSalt,
+        public ?string $maskChar,
+        public ?int $visibleChars,
+        public ?bool $preserveFormat,
+        public ?string $staticValue,
+        public ?string $remappingUse = null,
+        public ?array $remappingForeignKeys = null,
+    ) {}
+}
+```
+
+- [ ] **Step 3: Update KeyRemappingDtoTest**
+
+Open `tests/Unit/Data/Cloning/KeyRemappingDtoTest.php` and remove `rangeMin: ...,` and `rangeMax: ...,` lines from the constructor calls. Remove any assertion lines like `->and($table->rangeMin)->toBe(...)` and `->and($table->rangeMax)->toBe(...)`.
+
+- [ ] **Step 4: Run unit tests for the data layer**
+
+Run: `./vendor/bin/pest tests/Unit/Data/Cloning --no-coverage`
+Expected: pass.
+
+- [ ] **Step 5: Commit (deferred — combine with Task 6 since callers will be broken until both done)**
+
+(No commit yet. Validator/loader/writer/dump references are about to be cleaned up.)
+
+---
+
+## Task 6: Drop range parsing from CloningYamlLoader
+
+**Files:**
+- Modify: `app/Services/Cloning/CloningYamlLoader.php`
+- Modify: `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php`
+
+- [ ] **Step 1: Inline-remapping branch — drop range pass-through**
+
+Edit lines 95-103 of `app/Services/Cloning/CloningYamlLoader.php`:
+
+```php
+$inlineRemappingTables[] = new KeyRemappingTableData(
+    table: $tableData->tableName,
+    primaryKey: $column->columnName,
+    strategy: KeyRemappingStrategy::tryFrom($column->remappingUse ?? 'random_integer') ?? KeyRemappingStrategy::RandomInteger,
+    foreignKeys: $column->remappingForeignKeys ?? [],
+);
+```
+
+- [ ] **Step 2: Legacy `key_remapping:` branch — drop range fields**
+
+Edit lines 207-244 of `mapKeyRemappingConfig()`. Remove the `$rangeMin = ...` and `$rangeMax = ...` lines (originally lines 209-210), and drop them from the `KeyRemappingTableData` constructor call (around line 237):
+
+```php
+$tables[] = new KeyRemappingTableData(
+    table: $table,
+    primaryKey: $primaryKey,
+    strategy: $strategy,
+    foreignKeys: $fks,
+);
+```
+
+- [ ] **Step 3: Inline column parsing — drop `min` / `max` arguments**
+
+Edit `mapColumnConfig()`. Remove the `$remappingMin = null;` and `$remappingMax = null;` declarations (lines 270-271), the `case 'min':` and `case 'max':` branches inside the foreach (lines 314-320), and the trailing `remappingMin: ...,` / `remappingMax: ...,` constructor args (lines 362-363).
+
+- [ ] **Step 4: Update CloningYamlLoaderTest**
+
+Open `tests/Unit/Services/Cloning/CloningYamlLoaderTest.php` and:
+
+1. Remove `range_min:` and `range_max:` lines from YAML literals at lines 275-276, 532-533.
+2. Remove assertion lines like `expect($table?->rangeMin)->toBe(...)` and `expect($table?->rangeMax)->toBe(...)` at lines 287-288, 459-460, 542-543.
+3. Remove inline-arg test assertions for `remappingMin` / `remappingMax` at lines 467-468.
+
+If a whole test exists solely to assert defaulting of range fields, delete that test entirely.
+
+- [ ] **Step 5: Run loader tests**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlLoaderTest.php --no-coverage`
+Expected: pass.
+
+---
+
+## Task 7: Drop range validation + add legacy-key rejection
+
+**Files:**
+- Modify: `app/Services/Cloning/CloningYamlValidator.php`
+- Modify: `tests/Unit/Services/Cloning/CloningYamlValidatorTest.php`
+
+- [ ] **Step 1: Replace legacy range validation with rejection**
+
+In `validateKeyRemapping()` (around lines 318-332), replace the entire `if (($strategy ?? '') === 'random_integer') { ... }` block with rejection:
+
+```php
+foreach (['range_min', 'range_max'] as $legacyKey) {
+    if (array_key_exists($legacyKey, $entry)) {
+        $errors[] = sprintf(
+            "%s: '%s' is no longer supported (auto-bounds is computed from column type — remove this line)",
+            $prefix,
+            $legacyKey,
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Reject inline `min` / `max` arguments**
+
+In `validateColumnStrategy()` `case 'remapping':` (lines 424-468), remove the `if ($use === 'random_integer') { ... }` block (the `$min`, `$max` checks). Add legacy-key rejection after the flatten loop, before the `$use` check:
+
+```php
+foreach (['min', 'max'] as $legacyKey) {
+    if (array_key_exists($legacyKey, $args)) {
+        $errors[] = sprintf(
+            "%s: 'remapping' argument '%s' is no longer supported (auto-bounds is computed from column type — remove this line)",
+            $prefix,
+            $legacyKey,
+        );
+    }
+}
+```
+
+- [ ] **Step 3: Update CloningYamlValidatorTest**
+
+Open `tests/Unit/Services/Cloning/CloningYamlValidatorTest.php`:
+
+1. In tests around lines 295-310 that include `'range_min' => 100000, 'range_max' => 9999999` in valid YAML: remove those lines.
+2. Replace the test at line 381 (`returns error when range_min >= range_max for random_integer strategy`) with a new test that asserts the new rejection message:
+
+```php
+it('returns error when legacy range_min/range_max keys are present', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $errors = $validator->validate([
+        'version' => '1',
+        'connection' => 'src',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'users' => ['rows' => ['strategy' => 'full']],
+        ],
+        'key_remapping' => [
+            'tables' => [
+                [
+                    'table' => 'users',
+                    'primary_key' => 'id',
+                    'strategy' => 'random_integer',
+                    'range_min' => 100000,
+                    'range_max' => 9999999,
+                ],
+            ],
+        ],
+    ]);
+
+    expect(implode(' ', $errors))
+        ->toContain("'range_min' is no longer supported")
+        ->and(implode(' ', $errors))
+        ->toContain("'range_max' is no longer supported");
+});
+
+it('returns error when legacy inline min/max remapping arguments are present', function (): void {
+    $validator = new CloningYamlValidator;
+
+    $errors = $validator->validate([
+        'version' => '1',
+        'connection' => 'src',
+        'options' => [
+            'chunk_size' => 1000,
+            'enforce_column_types' => false,
+            'drop_unknown_tables' => false,
+            'disable_foreign_key_checks' => true,
+            'faker_locale' => 'en_US',
+        ],
+        'tables' => [
+            'users' => [
+                'rows' => ['strategy' => 'full'],
+                'columns' => [
+                    'id' => [
+                        'strategy' => 'remapping',
+                        'arguments' => [
+                            ['use' => 'random_integer'],
+                            ['min' => 100000],
+                            ['max' => 9999999],
+                            ['foreign_keys' => []],
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ]);
+
+    expect(implode(' ', $errors))
+        ->toContain("'min' is no longer supported")
+        ->and(implode(' ', $errors))
+        ->toContain("'max' is no longer supported");
+});
+```
+
+- [ ] **Step 4: Run validator tests**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlValidatorTest.php --no-coverage`
+Expected: pass.
+
+---
+
+## Task 8: Drop range emission from CloningYamlWriter + DumpCommand
+
+**Files:**
+- Modify: `app/Services/Cloning/CloningYamlWriter.php` (lines 79-80)
+- Modify: `app/Commands/Cloning/DumpCommand.php` (lines 350-360 area)
+- Modify: `tests/Unit/Services/Cloning/CloningYamlWriterTest.php`
+
+- [ ] **Step 1: Remove range lines from writer**
+
+Delete lines 79-80 of `app/Services/Cloning/CloningYamlWriter.php`:
+
+```php
+// DELETE these two lines:
+// $lines[] = sprintf('          - min: %d', $krTable->rangeMin);
+// $lines[] = sprintf('          - max: %d', $krTable->rangeMax);
+```
+
+- [ ] **Step 2: Remove range args from DumpCommand**
+
+Edit `app/Commands/Cloning/DumpCommand.php`. Find the `KeyRemappingTableData` construction near line 350 and remove the `rangeMin: 100000,` / `rangeMax: 9999999,` lines (currently lines 356-357).
+
+- [ ] **Step 3: Update CloningYamlWriterTest**
+
+Open `tests/Unit/Services/Cloning/CloningYamlWriterTest.php`:
+
+1. Remove `rangeMin: 100000,` and `rangeMax: 9999999,` from `KeyRemappingTableData` constructor calls (lines 326-327, 367-368).
+2. Adjust expected YAML strings: any test asserting `- min:` / `- max:` lines in the rendered output must drop those lines from the expected string.
+
+- [ ] **Step 4: Run writer + dump tests**
+
+Run: `./vendor/bin/pest tests/Unit/Services/Cloning/CloningYamlWriterTest.php tests/Feature/Commands/Cloning --no-coverage`
+Expected: pass.
+
+- [ ] **Step 5: Commit (Task 5–8 combined)**
+
+```bash
+git add app/Data/Cloning/KeyRemappingTableData.php app/Data/Cloning/ColumnCloningConfigData.php app/Services/Cloning/CloningYamlLoader.php app/Services/Cloning/CloningYamlValidator.php app/Services/Cloning/CloningYamlWriter.php app/Commands/Cloning/DumpCommand.php tests/Unit/Data/Cloning/KeyRemappingDtoTest.php tests/Unit/Services/Cloning/CloningYamlLoaderTest.php tests/Unit/Services/Cloning/CloningYamlValidatorTest.php tests/Unit/Services/Cloning/CloningYamlWriterTest.php
+git commit -m "refactor(cloning): drop user-configurable key-remapping ranges"
+```
+
+---
+
+## Task 9: Wire sourceSchema into RunCommand
+
+**Files:**
+- Modify: `app/Commands/Cloning/RunCommand.php` (line 329)
+
+- [ ] **Step 1: Update generateMappings call**
+
+Find the call near line 329:
+
+```php
+fn (): array => $keyRemappingService->generateMappings($keyRemappingConfig, $sourceConnection, $sortedForMapping),
+```
+
+Change to:
+
+```php
+fn (): array => $keyRemappingService->generateMappings($keyRemappingConfig, $sourceConnection, $sourceSchema, $sortedForMapping),
+```
+
+`$sourceSchema` is already in scope (read at line 301).
+
+- [ ] **Step 2: Run feature tests**
+
+Run: `./vendor/bin/pest tests/Feature/Commands/Cloning --no-coverage`
+Expected: pass. If any feature test mocks `KeyRemappingService::generateMappings`, the mock signature needs the extra `DatabaseSchemaData` arg — fix in place.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add app/Commands/Cloning/RunCommand.php
+git commit -m "feat(cloning): pass source schema to key remapping for type-aware bounds"
+```
+
+---
+
+## Task 10: Update PRD and project memory
+
+**Files:**
+- Modify: `specs/PRD-cloning-key-remapping.md`
+
+- [ ] **Step 1: Edit PRD**
+
+Apply these edits to `specs/PRD-cloning-key-remapping.md`:
+
+1. Bump version header to `0.3` and date `2026-04-27`.
+2. In §3.1 example YAML: remove the `- min: 100000` and `- max: 9999999` lines from each `arguments:` block.
+3. In §3.2 field reference table: remove the `min` and `max` rows.
+4. In §3.3 legacy YAML example: remove `range_min: 100000` and `range_max: 9999999`.
+5. In §3.4 validation rules: remove the `range_min must be ≥ 1 and < range_max` bullet. Add: `Legacy keys (min, max, range_min, range_max) produce a hard validation error directing the user to remove them.`
+6. In §4.1 Phase 5b strategy: replace bullet 2's `random_integer` description with:
+   > `random_integer`: allocate IDs ascending starting at `MAX(source.pk) + 1`, capped at the column's type ceiling (TINYINT=255 unsigned/127 signed, SMALLINT=65535/32767, MEDIUMINT=16777215/8388607, INT=4294967295/2147483647, BIGINT=PHP_INT_MAX). If the upper region is too small, fall back to filling unused gaps in `[1, MAX(id)]`. If neither has room for the row count, abort with `KeyRemappingExhaustedException` (`ExitCode::GeneralError`).
+7. In §6 Dry-run output example: change `key_remapping  users.id → random_integer [100000–9999999]` to `key_remapping  users.id → random_integer (auto, INT UNSIGNED ceiling 4294967295)`.
+8. In §7 audit log: remove `range_min` and `range_max` keys from the example JSON.
+9. In §9 error handling table: change `Range exhausted (random_integer)` row to `Type ceiling cannot host row count` with the new exception name.
+10. In §10 constraints: remove the `range must be large enough` bullet. Add: `If the source PK column is narrower than the row count requires, the run aborts before any data is written. Choose a wider column type or reduce row scope.`
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add specs/PRD-cloning-key-remapping.md docs/superpowers/plans/2026-04-27-key-remapping-auto-bounds.md specs/2026-04-27-key-remapping-auto-bounds.md
+git commit -m "docs(specs): document auto-bounds key remapping (no user-configured ranges)"
+```
+
+---
+
+## Task 11: Full verification
+
+- [ ] **Step 1: Lint**
+
+Run: `composer lint`
+Expected: 0 changes / clean.
+
+- [ ] **Step 2: Static analysis**
+
+Run: `composer test:types`
+Expected: 0 errors.
+
+- [ ] **Step 3: Type coverage**
+
+Run: `composer test:type-coverage`
+Expected: ≥ 90%.
+
+- [ ] **Step 4: Unit + feature tests**
+
+Run: `composer test:unit`
+Expected: all pass, coverage ≥ 75%.
+
+- [ ] **Step 5: Full suite**
+
+Run: `composer test`
+Expected: all green.
+
+- [ ] **Step 6: Manual smoke check (skip if no real MySQL fixture available)**
+
+If a local MySQL with the original failing schema is available, re-run a small `cloning:run` against a subset and confirm the duplicate-entry error is gone. Otherwise, document the manual test in the PR description for reviewer follow-up.
+
+- [ ] **Step 7: Final commit if any cleanups were made**
+
+```bash
+git status
+# if clean, no commit needed.
+```

--- a/specs/2026-04-27-key-remapping-auto-bounds.md
+++ b/specs/2026-04-27-key-remapping-auto-bounds.md
@@ -1,0 +1,214 @@
+# Spec — Key Remapping with Automatic Type-Aware Bounds
+
+**Date:** 2026-04-27
+**Status:** Draft
+**Supersedes:** range-based configuration in `PRD-cloning-key-remapping.md` v0.2 (sections 3.2 `min`/`max`, 3.4 range validation, 4.1 `random_integer` strategy)
+
+---
+
+## 1. Problem
+
+`cloning:run` with `random_integer` key remapping produces duplicate-entry errors during INSERT:
+
+```
+SQLSTATE[23000]: Integrity constraint violation: 1062
+Duplicate entry '2889387-65535-255' for key 'werkstatt_netz2institution.composite_key'
+```
+
+Root cause: the remapper draws random integers from a user-configured range `[range_min, range_max]` (default `[100000, 9999999]`) without inspecting the target column's type. When the column is narrower than the range (e.g. `SMALLINT UNSIGNED` max `65535`, `TINYINT UNSIGNED` max `255`), MySQL non-strict mode silently clamps overflowed values to the column's type ceiling. Multiple distinct source IDs all collapse to the same ceiling value, producing duplicate composite keys downstream.
+
+Secondary problems:
+
+- The range is a footgun: users must know the schema's narrowest PK column to pick a valid range, and have no feedback when they get it wrong.
+- Random selection requires collision dedup within a run (current `$usedIntegers` set) and degrades sharply when the range is small (loop on collisions).
+- Random IDs are non-deterministic and harder to debug than ordered IDs.
+
+## 2. Goal
+
+Remove the `min` / `max` / `range_min` / `range_max` configuration knobs entirely. Replace the `random_integer` strategy with an automatic, type-aware, deterministic integer-id strategy that:
+
+1. Inspects the source column's data type and unsigned flag to compute a hard upper bound (`typeMax`).
+2. Allocates new IDs sequentially starting at `MAX(id) + 1` (where `MAX(id)` is read from the source PK column).
+3. Falls back to filling unused gaps in `[1, MAX(id)]` if the upper region runs out.
+4. Aborts with a clear, actionable error if the column type cannot host the required row count.
+
+The `new_uuid` strategy is unchanged.
+
+## 3. Non-Goals
+
+- No backward compatibility for legacy YAML files containing `min`, `max`, `range_min`, `range_max`. Pre-1.0.0 — clean break. Validator hard-errors on legacy keys to force user migration.
+- No optional offset / shift knob. If real users ask for one later, add it then.
+- No support for negative-range PKs (signed types are still supported, but new IDs are always allocated in the positive half: `[max(MAX(id)+1, 1), typeMax]`).
+- No change to `cloning:dump` FK discovery, junction-table handling, or the rest of the run pipeline.
+
+## 4. Design
+
+### 4.1 Type ceiling table
+
+Implemented as a pure helper, `KeyTypeBoundsResolver::ceilingFor(ColumnSchemaData $col): int`.
+
+Mapping (case-insensitive `$col->type`):
+
+| Type token | Signed ceiling | Unsigned ceiling |
+| --- | --- | --- |
+| `tinyint` | 127 | 255 |
+| `smallint` | 32767 | 65535 |
+| `mediumint` | 8388607 | 16777215 |
+| `int`, `integer` | 2147483647 | 4294967295 |
+| `bigint` | `PHP_INT_MAX` (9223372036854775807) | `PHP_INT_MAX` (we do not return values > `PHP_INT_MAX`) |
+
+Other types (`varchar`, `char`, `uuid`, `text`, …) → throw `UnsupportedKeyColumnTypeException`. The remapping service must only call the resolver after confirming the strategy is `RandomInteger` (was named `random_integer` in YAML — see §5 for rename rationale).
+
+Unsigned detection: only meaningful for MySQL/MariaDB. For Postgres, SQLite, SQL Server: treat as signed (those drivers don't expose `UNSIGNED`). The resolver consumes a single `bool $unsigned` field on `ColumnSchemaData`.
+
+### 4.2 ID allocation strategy
+
+Pseudocode for one remapped table:
+
+```
+input:  ColumnSchemaData $pk     // type + unsigned + name
+        list<int|string> $sourceIds   // raw PK values from source
+output: array<string,string> $mapping // oldId(stringified) → newId(stringified)
+
+typeMax    = KeyTypeBoundsResolver::ceilingFor($pk)
+existing   = sort(unique(intval-cast of $sourceIds, dropping non-numeric))
+maxExisting = empty(existing) ? 0 : last(existing)
+rowCount   = count($sourceIds)
+
+upperStart = max(maxExisting + 1, 1)
+upperSlots = max(0, typeMax - upperStart + 1)
+
+if upperSlots >= rowCount:
+    targets = range(upperStart, upperStart + rowCount - 1)
+else:
+    needed   = rowCount - upperSlots
+    upperPart = upperSlots > 0 ? range(upperStart, typeMax) : []
+    gaps     = findGaps(existing, lo=1, hi=maxExisting)   // ascending, ints
+    if count(gaps) < needed:
+        throw KeyRemappingExhaustedException(table, column, typeMax, rowCount, upperSlots, count(gaps))
+    targets = concat(upperPart, take(gaps, needed))
+
+assign source-row order to targets in order:
+for i, sourceId in enumerate(sourceIds):
+    mapping[(string) sourceId] = (string) targets[i]
+return mapping
+```
+
+Notes:
+
+- `findGaps` returns ascending `int`s in `[lo, hi]` not present in `existing`. Implementation can be a single linear sweep over the sorted `existing` list — no per-iteration set membership test.
+- Output values are stringified to preserve compatibility with the existing `KeyRemappingStoreInterface` contract (`array<string,string>`).
+- Self-referential FK handling and the rest of `applyToRow` are unchanged.
+
+### 4.3 Exhaustion error
+
+```php
+throw new KeyRemappingExhaustedException(
+    "Cannot remap table '{$table}': column '{$col}' is {$type} ({$signedness}, ceiling {$typeMax}); "
+  . "{$rowCount} rows requested, only {$availableSlots} slots available "
+  . "({$upperSlots} above MAX(id), {$gapSlots} gaps below)."
+);
+```
+
+Surfaced by `cloning:run` as `ExitCode::GeneralError`, with the message printed verbatim in the failure summary.
+
+### 4.4 Phase 5b verbose output
+
+```
+✓ Key mapping generated for werkstatt_netz2institution (1,247,532 rows; INT UNSIGNED, MAX(id)=2,889,387)
+```
+
+Format is decorative; must include row count + column type + signedness for debugging.
+
+## 5. YAML schema changes
+
+### 5.1 Inline `strategy: remapping`
+
+Remove `min` and `max` from the `arguments` list. Only `use` and `foreign_keys` remain.
+
+```yaml
+columns:
+  id:
+    strategy: remapping
+    arguments:
+      - use: random_integer
+      - foreign_keys:
+          - table: orders
+            column: user_id
+```
+
+> The token `random_integer` is retained for now to keep the YAML contract stable, even though the new strategy is deterministic. Renaming to `auto_integer` is a follow-up nicety, not required by this spec.
+
+### 5.2 Legacy top-level `key_remapping:` section
+
+Remove `range_min` and `range_max` from each table entry.
+
+```yaml
+key_remapping:
+  tables:
+    - table: users
+      primary_key: id
+      strategy: random_integer
+      foreign_keys: [...]
+```
+
+### 5.3 Validator behaviour
+
+- `min`, `max`, `range_min`, `range_max` are now **unknown keys**. The validator must produce a hard error naming each occurrence:
+
+  ```
+  key_remapping.tables[0]: 'range_min' is no longer supported (auto-bounds is computed from column type)
+  Table 'users', column 'id': remapping argument 'min' is no longer supported (auto-bounds is computed from column type)
+  ```
+
+- The order check (`min < max`) is removed.
+- The `>= 1` check on `min`/`max` is removed.
+
+### 5.4 `cloning:dump` output
+
+`DumpCommand` no longer emits `min`/`max` / `range_min`/`range_max`. The generated YAML contains only `use: random_integer` plus `foreign_keys`.
+
+## 6. Code changes (overview)
+
+| File | Change |
+| --- | --- |
+| `app/Data/Schema/ColumnSchemaData.php` | Add `bool $unsigned` (default `false`) |
+| `app/Services/Schema/SchemaInspector.php` (MySQL branch only) | Read `COLUMN_TYPE`, set `unsigned = str_contains(strtolower($columnType), 'unsigned')` |
+| `app/Data/Cloning/KeyRemappingTableData.php` | Drop `rangeMin`, `rangeMax` |
+| `app/Data/Cloning/ColumnCloningConfigData.php` | Drop `remappingMin`, `remappingMax` |
+| `app/Services/Cloning/CloningYamlLoader.php` | Drop range parsing in inline + legacy branches |
+| `app/Services/Cloning/CloningYamlValidator.php` | Hard-error on `min`/`max`/`range_min`/`range_max`; drop range checks |
+| `app/Services/Cloning/CloningYamlWriter.php` | Drop `- min:` / `- max:` emission |
+| `app/Commands/Cloning/DumpCommand.php` | Drop `rangeMin`/`rangeMax` constructor args |
+| `app/Services/Cloning/KeyTypeBoundsResolver.php` (new) | Pure type-ceiling helper + `ceilingFor()`; throws `UnsupportedKeyColumnTypeException` |
+| `app/Exceptions/KeyRemappingExhaustedException.php` (new) | RuntimeException subclass with table/column/typeMax/rowCount fields |
+| `app/Exceptions/UnsupportedKeyColumnTypeException.php` (new) | RuntimeException subclass for unsupported column types |
+| `app/Services/Cloning/KeyRemappingService.php` | Accept `DatabaseSchemaData`; rewrite `generateTableMapping`; remove `generateUniqueInteger` |
+| `app/Commands/Cloning/RunCommand.php` (line 329) | Pass `$sourceSchema` to `generateMappings()` |
+| Tests | Update DTO, loader, validator, writer, dump, key remapping service tests |
+
+## 7. Test plan
+
+New tests (Pest):
+
+- `KeyTypeBoundsResolverTest` — TINYINT/SMALLINT/MEDIUMINT/INT/BIGINT × signed/unsigned matrix + unsupported-type error.
+- `KeyRemappingServiceTest` (extended):
+  - empty table → empty mapping
+  - 5 rows in TINYINT UNSIGNED with `MAX(id)=200` → IDs `[201..205]`
+  - 5 rows in TINYINT UNSIGNED with `MAX(id)=253` → IDs `[254, 255, gap, gap, gap]` (gap-fill kicks in)
+  - 300 rows in TINYINT UNSIGNED → `KeyRemappingExhaustedException`
+  - INT signed: never returns negative IDs
+  - empty source table (`MAX(id)=null`) → IDs start at 1
+  - `new_uuid` strategy still produces UUIDs (regression)
+- `CloningYamlValidatorTest` — adds cases that legacy `min`/`max`/`range_min`/`range_max` are rejected.
+- `CloningYamlLoaderTest` — drop existing range-parsing tests; add round-trip test for cleaned schema.
+- `CloningYamlWriterTest` — assert no `- min:` / `- max:` lines emitted.
+
+## 8. Migration / breakpoints for users
+
+Pre-1.0.0 — no migration tooling. Users with legacy YAML containing range fields will see a validation error pointing to the offending key. Resolution: delete the line and re-run.
+
+## 9. Open questions
+
+- Should the bounds resolver expose a "max safe int" cap below `PHP_INT_MAX` for BIGINT? PHP arithmetic is safe up to `PHP_INT_MAX`; MySQL unsigned BIGINT can exceed it. For now, cap at `PHP_INT_MAX` and document.
+- Should we warn when the resolver yields a tight margin (e.g. `< 10%` headroom) in verbose mode? Not in scope for this spec.

--- a/specs/PRD-cloning-key-remapping.md
+++ b/specs/PRD-cloning-key-remapping.md
@@ -1,8 +1,10 @@
 # PRD — Key Remapping in `cloning:run`
 
-**Version:** 0.2
+**Version:** 0.3
 **Status:** Draft
-**Date:** 2026-04-02
+**Date:** 2026-04-27
+
+> **Change in v0.3 (2026-04-27):** removed the user-configurable `min` / `max` / `range_min` / `range_max` knobs from the `random_integer` strategy. Bounds are now derived automatically from the source PK column's data type and `MAX(id)`. See companion spec `specs/2026-04-27-key-remapping-auto-bounds.md` for design details.
 
 ---
 
@@ -52,8 +54,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: orders
                 column: user_id
@@ -80,8 +80,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: order_items
                 column: order_id
@@ -106,8 +104,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys:
               - table: employees
                 column: manager_id
@@ -131,9 +127,9 @@ The remapping strategy is configured via an `arguments` list of single-key mappi
 | Argument key | Type | Required | Description |
 | --- | --- | --- | --- |
 | `use` | enum | yes | `random_integer` or `new_uuid` |
-| `min` | integer | only for `random_integer` | Lower bound, inclusive. Default: 100000. |
-| `max` | integer | only for `random_integer` | Upper bound, inclusive. Default: 9999999. |
 | `foreign_keys` | list | yes | FK columns on other (or the same) tables that reference this column. May be empty (`[]`). |
+
+> **Removed in v0.3:** `min` and `max` are no longer accepted. Integer bounds are derived automatically from the source PK column's data type (signed/unsigned) and `MAX(id)`. Files that still contain these keys produce a hard validation error.
 
 Each entry in `foreign_keys`:
 
@@ -154,8 +150,6 @@ key_remapping:
     - table: users
       primary_key: id
       strategy: random_integer
-      range_min: 100000
-      range_max: 9999999
       foreign_keys:
         - table: posts
           column: user_id
@@ -173,7 +167,7 @@ key_remapping:
 ### 3.4 Validation rules
 
 - `strategy: new_uuid` is only valid when `primary_key` is a UUID/CHAR(36) column. The validator checks the source schema if a connection is available; otherwise it is accepted and fails at runtime.
-- `range_min` must be `≥ 1` and `< range_max`.
+- Legacy keys `min`, `max`, `range_min`, `range_max` produce a hard validation error directing the user to remove them — bounds are now derived from the column type.
 - No two entries in `key_remapping.tables` may reference the same `table`.
 - A table listed in `key_remapping.tables` must also appear in `tables`.
 - A FK entry referencing a table that is not in `tables` is a warning, not a hard error (the FK update will be skipped for unlisted tables).
@@ -206,12 +200,12 @@ For each table in `key_remapping.tables` (processed in dependency order):
 
 1. Read all primary key values from the source table, respecting the table's `rows` strategy (full / first N / last N with the configured `sort_by` and `limit`).
 2. For each source PK value, generate a new value:
-   - `random_integer`: draw a random integer in `[range_min, range_max]`. Retry if already used in this run (in-memory collision set). If the range is exhausted, abort with `ExitCode::GeneralError`.
+   - `random_integer`: derive the column's integer ceiling from its data type and unsigned flag (`TINYINT` 127/255, `SMALLINT` 32767/65535, `MEDIUMINT` 8388607/16777215, `INT` 2147483647/4294967295, `BIGINT` `PHP_INT_MAX`). Allocate IDs ascending starting at `MAX(source.pk) + 1`, capped at the ceiling. If the upper region is too small for the row count, fall back to filling unused gaps in `[1, MAX(id)]`. If neither region has room, abort with `KeyRemappingExhaustedException` (`ExitCode::GeneralError`).
    - `new_uuid`: generate a UUID v7.
 3. Store the mapping as `old_value → new_value` in an in-memory map keyed by `table.primary_key`.
 4. Mappings are scoped to this run instance and are never written to the target database.
 
-Output (verbose only): `✓ Key mapping generated for users (12,450 rows)`
+Output (verbose only): `✓ Key mapping generated for users (12,450 rows; INT UNSIGNED, MAX(id)=2,889,387)`
 
 ### 4.2 Phase 6 — Data Transfer (modified)
 
@@ -260,7 +254,7 @@ php clonio cloning:run --skip-remapping-keys
 When `--dry-run` is active, Phase 5b is executed but generates no in-memory mappings. Instead, for each remapped table the dry-run output shows:
 
 ```
-  key_remapping  users.id → random_integer [100000–9999999]
+  key_remapping  users.id → random_integer (auto, INT UNSIGNED ceiling 4294967295)
 ```
 
 This is appended to the per-table block in the existing dry-run table output.
@@ -280,8 +274,9 @@ The audit record produced in Phase 8 is extended with a `key_remapping` block:
         "table": "users",
         "primary_key": "id",
         "strategy": "random_integer",
-        "range_min": 100000,
-        "range_max": 9999999,
+        "column_type": "int",
+        "unsigned": true,
+        "type_ceiling": 4294967295,
         "rows_remapped": 12450,
         "rows_skipped_unique_violation": 3,
         "rows_skipped_fk_violation": 1
@@ -313,7 +308,8 @@ The resulting `key_remapping` section is ready for use without manual edits in t
 
 | Condition | Behaviour |
 | --- | --- |
-| Range exhausted (random_integer) | Abort run with `ExitCode::GeneralError`; print table name and range in error message. |
+| Type ceiling cannot host row count (random_integer) | Abort run with `ExitCode::GeneralError` raised as `KeyRemappingExhaustedException`; message names table, column, type, ceiling, row count, and slot accounting (above MAX(id) vs gaps below). |
+| PK column type unsupported (random_integer) | Abort with `UnsupportedKeyColumnTypeException` (e.g. `random_integer` requested on a `varchar` column). |
 | Source PK column not found on source | Abort at Phase 5b with validation error. |
 | FK column not found on FK table | Warning logged; FK column not rewritten. |
 | Self-referential second-pass update fails | Warning logged; row is left with original FK value. |
@@ -324,7 +320,7 @@ The resulting `key_remapping` section is ready for use without manual edits in t
 ## 10. Constraints and Limitations
 
 - Only **single-column primary keys** are supported for remapping. Composite PKs that are not pure-FK junction tables are not supported and must not appear in `key_remapping.tables`.
-- The **range must be large enough** for the number of rows being transferred. There is no automatic range expansion.
+- The **column type must be wide enough** for `MAX(id) + rowCount` (or for `MAX(id)` plus enough gaps below it). If neither region has room, the run aborts before any data is written. To resolve, widen the source PK column type or reduce row scope via the table's `rows` strategy.
 - All tables whose FK columns reference a remapped table must themselves be included in the `tables` section; otherwise FK rewriting is silently skipped for missing tables.
 - Key mappings are **in-memory only** for the CLI. Unlike the web app, there is no `cloning_run_key_mappings` database table; the CLI holds the full mapping in RAM. For very large tables, memory usage should be monitored.
 

--- a/tests/Feature/Commands/Cloning/DumpCommandTest.php
+++ b/tests/Feature/Commands/Cloning/DumpCommandTest.php
@@ -304,8 +304,8 @@ it('includes key_remapping section for tables with integer primary keys', functi
     expect($yaml)->not->toContain('key_remapping:');
     expect($yaml)->toContain('strategy: remapping');
     expect($yaml)->toContain('- use: random_integer');
-    expect($yaml)->toContain('- min: 100000');
-    expect($yaml)->toContain('- max: 9999999');
+    expect($yaml)->not->toContain('- min:');
+    expect($yaml)->not->toContain('- max:');
     expect($yaml)->toContain('column: user_id');
     expect($yaml)->toContain('self_referential: false');
 });

--- a/tests/Unit/Data/Cloning/KeyRemappingDtoTest.php
+++ b/tests/Unit/Data/Cloning/KeyRemappingDtoTest.php
@@ -13,8 +13,6 @@ function makeTableData(string $table = 'users', string $pk = 'id'): KeyRemapping
         table: $table,
         primaryKey: $pk,
         strategy: KeyRemappingStrategy::NewUuid,
-        rangeMin: 1,
-        rangeMax: 999999,
         foreignKeys: [],
     );
 }
@@ -37,16 +35,12 @@ it('KeyRemappingTableData stores fields correctly', function (): void {
         table: 'users',
         primaryKey: 'id',
         strategy: KeyRemappingStrategy::RandomInteger,
-        rangeMin: 100,
-        rangeMax: 999999,
         foreignKeys: [$fk],
     );
 
     expect($table->table)->toBe('users')
         ->and($table->primaryKey)->toBe('id')
         ->and($table->strategy)->toBe(KeyRemappingStrategy::RandomInteger)
-        ->and($table->rangeMin)->toBe(100)
-        ->and($table->rangeMax)->toBe(999999)
         ->and($table->foreignKeys)->toHaveCount(1);
 });
 

--- a/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
@@ -272,8 +272,6 @@ key_remapping:
     - table: orders
       primary_key: id
       strategy: random_integer
-      range_min: 100000
-      range_max: 9999999
 YAML;
 
     Storage::disk('local')->put('int-remapping.yaml', $yaml);
@@ -284,8 +282,6 @@ YAML;
     $table = $config->keyRemapping?->getTable('orders');
     expect($table)->not->toBeNull();
     expect($table?->strategy->value)->toBe('random_integer');
-    expect($table?->rangeMin)->toBe(100000);
-    expect($table?->rangeMax)->toBe(9999999);
 });
 
 it('sets keyRemapping to null when section is absent', function (): void {
@@ -436,8 +432,6 @@ tables:
         strategy: remapping
         arguments:
           - use: random_integer
-          - min: 100000
-          - max: 9999999
           - foreign_keys: []
       email:
         strategy: fake
@@ -456,16 +450,12 @@ YAML;
     expect($krTable)->not->toBeNull();
     expect($krTable?->primaryKey)->toBe('id');
     expect($krTable?->strategy->value)->toBe('random_integer');
-    expect($krTable?->rangeMin)->toBe(100000);
-    expect($krTable?->rangeMax)->toBe(9999999);
     expect($krTable?->foreignKeys)->toBe([]);
 
     // The remapping column itself is accessible
     $idCol = $config->getTable('users')?->getColumn('id');
     expect($idCol?->strategy)->toBe('remapping');
     expect($idCol?->remappingUse)->toBe('random_integer');
-    expect($idCol?->remappingMin)->toBe(100000);
-    expect($idCol?->remappingMax)->toBe(9999999);
 });
 
 it('loads inline remapping with new_uuid strategy', function (): void {
@@ -520,27 +510,22 @@ tables:
       id:
         strategy: remapping
         arguments:
-          - use: random_integer
-          - min: 200000
-          - max: 8888888
+          - use: new_uuid
           - foreign_keys: []
 key_remapping:
   tables:
     - table: users
       primary_key: id
       strategy: random_integer
-      range_min: 1
-      range_max: 99
 YAML;
 
     Storage::disk('local')->put('both.yaml', $yaml);
 
     $config = (new CloningYamlLoader)->load('both.yaml');
 
-    // Inline wins — range from inline config
+    // Inline wins — strategy from inline config (new_uuid), not legacy (random_integer)
     $krTable = $config->keyRemapping?->getTable('users');
-    expect($krTable?->rangeMin)->toBe(200000);
-    expect($krTable?->rangeMax)->toBe(8888888);
+    expect($krTable?->strategy->value)->toBe('new_uuid');
 });
 
 it('parses drop_extra_columns option when present', function (): void {

--- a/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
@@ -297,8 +297,6 @@ it('passes validation for a valid key_remapping section with random_integer stra
                 'table' => 'users',
                 'primary_key' => 'id',
                 'strategy' => 'random_integer',
-                'range_min' => 100000,
-                'range_max' => 9999999,
             ],
         ],
     ];
@@ -378,7 +376,7 @@ it('returns error for invalid strategy in key_remapping', function (): void {
     expect(implode(' ', $errors))->toContain("'strategy' must be one of");
 });
 
-it('returns error when range_min >= range_max for random_integer strategy', function (): void {
+it('returns error when legacy range_min/range_max keys are present', function (): void {
     $validator = new CloningYamlValidator;
     $config = makeValidConfig();
     $config['key_remapping'] = [
@@ -387,14 +385,37 @@ it('returns error when range_min >= range_max for random_integer strategy', func
                 'table' => 'users',
                 'primary_key' => 'id',
                 'strategy' => 'random_integer',
-                'range_min' => 9999999,
-                'range_max' => 100000,
+                'range_min' => 100000,
+                'range_max' => 9999999,
             ],
         ],
     ];
 
     $errors = $validator->validate($config);
-    expect(implode(' ', $errors))->toContain("'range_min' must be less than 'range_max'");
+    $joined = implode(' ', $errors);
+    expect($joined)->toContain("'range_min' is no longer supported")
+        ->and($joined)->toContain("'range_max' is no longer supported");
+});
+
+it('returns error when legacy inline min/max remapping arguments are present', function (): void {
+    $validator = new CloningYamlValidator;
+    $config = makeValidConfig();
+    $config['tables']['users']['columns'] = [
+        'id' => [
+            'strategy' => 'remapping',
+            'arguments' => [
+                ['use' => 'random_integer'],
+                ['min' => 100000],
+                ['max' => 9999999],
+                ['foreign_keys' => []],
+            ],
+        ],
+    ];
+
+    $errors = $validator->validate($config);
+    $joined = implode(' ', $errors);
+    expect($joined)->toContain("'min' is no longer supported")
+        ->and($joined)->toContain("'max' is no longer supported");
 });
 
 it('passes with valid foreign_keys in key_remapping', function (): void {
@@ -479,8 +500,6 @@ it('passes validation for a valid remapping column with random_integer', functio
         'strategy' => 'remapping',
         'arguments' => [
             ['use' => 'random_integer'],
-            ['min' => 100000],
-            ['max' => 9999999],
             ['foreign_keys' => []],
         ],
     ];
@@ -507,31 +526,13 @@ it('returns error when remapping strategy has no use argument', function (): voi
     $config['tables']['users']['columns']['id'] = [
         'strategy' => 'remapping',
         'arguments' => [
-            ['min' => 100000],
-            ['max' => 9999999],
+            ['foreign_keys' => []],
         ],
     ];
 
     $errors = $validator->validate($config);
     expect($errors)->not->toBe([]);
     expect(implode(' ', $errors))->toContain("'remapping' requires argument 'use'");
-});
-
-it('returns error when remapping random_integer has min greater than or equal to max', function (): void {
-    $validator = new CloningYamlValidator;
-    $config = makeValidConfig();
-    $config['tables']['users']['columns']['id'] = [
-        'strategy' => 'remapping',
-        'arguments' => [
-            ['use' => 'random_integer'],
-            ['min' => 9999999],
-            ['max' => 100000],
-        ],
-    ];
-
-    $errors = $validator->validate($config);
-    expect($errors)->not->toBe([]);
-    expect(implode(' ', $errors))->toContain("'min' must be less than 'max'");
 });
 
 it('accepts drop_extra_columns as optional boolean when present', function (): void {

--- a/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
@@ -323,8 +323,6 @@ it('writes remapping strategy as inline column not key_remapping section', funct
             table: 'users',
             primaryKey: 'id',
             strategy: KeyRemappingStrategy::RandomInteger,
-            rangeMin: 100000,
-            rangeMax: 9999999,
             foreignKeys: [],
         ),
     ]);
@@ -343,9 +341,10 @@ it('writes remapping strategy as inline column not key_remapping section', funct
     // Remapping must be inline in columns
     expect($yaml)->toContain('strategy: remapping');
     expect($yaml)->toContain('- use: random_integer');
-    expect($yaml)->toContain('- min: 100000');
-    expect($yaml)->toContain('- max: 9999999');
     expect($yaml)->toContain('- foreign_keys: []');
+    // No legacy range knobs
+    expect($yaml)->not->toContain('- min:');
+    expect($yaml)->not->toContain('- max:');
     // The old top-level section must NOT appear
     expect($yaml)->not->toContain('key_remapping:');
 });
@@ -364,8 +363,6 @@ it('does not duplicate primary key column when key remapping is active', functio
             table: 'users',
             primaryKey: 'id',
             strategy: KeyRemappingStrategy::RandomInteger,
-            rangeMin: 100000,
-            rangeMax: 9999999,
             foreignKeys: [],
         ),
     ]);

--- a/tests/Unit/Services/Cloning/KeyRemappingServiceTest.php
+++ b/tests/Unit/Services/Cloning/KeyRemappingServiceTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Data\Cloning\KeyRemappingConfigData;
 use App\Data\Cloning\KeyRemappingForeignKeyData;
 use App\Data\Cloning\KeyRemappingTableData;
+use App\Data\Schema\ColumnSchemaData;
 use App\Enums\KeyRemappingStrategy;
+use App\Exceptions\KeyRemappingExhaustedException;
 use App\Services\Cloning\InMemoryKeyRemappingStore;
 use App\Services\Cloning\KeyRemappingService;
 use App\Services\Database\DatabaseConnectionService;
@@ -25,9 +27,19 @@ function makeKeyRemappingTable(string $table, string $pk = 'id', array $fks = []
         table: $table,
         primaryKey: $pk,
         strategy: KeyRemappingStrategy::NewUuid,
-        rangeMin: 1,
-        rangeMax: 999999,
         foreignKeys: $fks,
+    );
+}
+
+function makePkCol(string $type, bool $unsigned = false): ColumnSchemaData
+{
+    return new ColumnSchemaData(
+        name: 'id',
+        type: $type,
+        nullable: false,
+        default: null,
+        isPrimary: true,
+        unsigned: $unsigned,
     );
 }
 
@@ -88,8 +100,6 @@ it('applyToRow remaps foreign key columns referencing another remapped table', f
         table: 'users',
         primaryKey: 'id',
         strategy: KeyRemappingStrategy::NewUuid,
-        rangeMin: 1,
-        rangeMax: 999999,
         foreignKeys: [$fk],
     );
     $config = new KeyRemappingConfigData([$usersTable]);
@@ -126,4 +136,85 @@ it('applyToRow does not modify row for unconfigured table', function (): void {
     $result = $service->applyToRow($row, 'unconfigured_table', $config);
 
     expect($result)->toBe($row);
+});
+
+it('allocateIntegerIds returns ascending ids starting at MAX(id)+1', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('tinyint', true); // ceiling 255
+
+    $sourceIds = ['10', '20', '30', '40', '50'];
+    $existingMax = 200;
+
+    $result = $service->allocateIntegerIds('users', $col, $sourceIds, $existingMax, []);
+
+    expect(array_values($result))->toBe(['201', '202', '203', '204', '205'])
+        ->and(array_keys($result))->toBe([10, 20, 30, 40, 50]);
+});
+
+it('allocateIntegerIds falls back to gap-fill when upper region exhausted', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('tinyint', true); // ceiling 255
+
+    $sourceIds = ['1', '2', '3', '4', '5'];
+    $existingMax = 253;
+    $existingIds = [1, 2, 250, 251, 252, 253]; // gaps in [1,253] = [3..249] (lots of room)
+
+    $result = $service->allocateIntegerIds('users', $col, $sourceIds, $existingMax, $existingIds);
+
+    // upper slots: 255 - 254 + 1 = 2 → IDs 254, 255
+    // remaining 3: first 3 gaps (skipping existing 1,2) = 3, 4, 5
+    expect(array_values($result))->toBe(['254', '255', '3', '4', '5']);
+});
+
+it('allocateIntegerIds throws when type ceiling cannot host row count', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('tinyint', true); // ceiling 255
+
+    $sourceIds = array_map(static fn (int $i): string => (string) $i, range(1, 300));
+    $existingMax = 0;
+
+    $service->allocateIntegerIds('big_table', $col, $sourceIds, $existingMax, []);
+})->throws(KeyRemappingExhaustedException::class);
+
+it('allocateIntegerIds starts at 1 when source table is empty (existingMax=0)', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('int');
+
+    $result = $service->allocateIntegerIds('users', $col, ['7'], 0, []);
+
+    expect($result)->toBe([7 => '1']);
+});
+
+it('allocateIntegerIds for signed int never returns negative ids', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('int'); // signed ceiling 2147483647
+
+    $result = $service->allocateIntegerIds('users', $col, ['1', '2'], 0, []);
+
+    expect(array_values($result))->toBe(['1', '2']);
+});
+
+it('allocateIntegerIds preserves source order when assigning new ids', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('int', true);
+
+    $sourceIds = ['100', '99', '500', '7'];
+
+    $result = $service->allocateIntegerIds('t', $col, $sourceIds, 1000, []);
+
+    expect($result)->toBe([
+        100 => '1001',
+        99 => '1002',
+        500 => '1003',
+        7 => '1004',
+    ]);
+});
+
+it('allocateIntegerIds returns empty mapping for empty source', function (): void {
+    $service = makeKeyRemappingService();
+    $col = makePkCol('int');
+
+    $result = $service->allocateIntegerIds('users', $col, [], 0, []);
+
+    expect($result)->toBe([]);
 });

--- a/tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php
+++ b/tests/Unit/Services/Cloning/KeyTypeBoundsResolverTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\Schema\ColumnSchemaData;
+use App\Exceptions\UnsupportedKeyColumnTypeException;
+use App\Services\Cloning\KeyTypeBoundsResolver;
+
+function makeIntCol(string $type, bool $unsigned = false): ColumnSchemaData
+{
+    return new ColumnSchemaData(
+        name: 'id',
+        type: $type,
+        nullable: false,
+        default: null,
+        isPrimary: true,
+        unsigned: $unsigned,
+    );
+}
+
+it('returns 127 for signed tinyint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('tinyint')))->toBe(127);
+});
+
+it('returns 255 for unsigned tinyint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('tinyint', true)))->toBe(255);
+});
+
+it('returns 32767 for signed smallint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('smallint')))->toBe(32767);
+});
+
+it('returns 65535 for unsigned smallint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('smallint', true)))->toBe(65535);
+});
+
+it('returns 8388607 for signed mediumint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('mediumint')))->toBe(8388607);
+});
+
+it('returns 16777215 for unsigned mediumint', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('mediumint', true)))->toBe(16777215);
+});
+
+it('returns 2147483647 for signed int', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('int')))->toBe(2147483647);
+});
+
+it('returns 4294967295 for unsigned int', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('int', true)))->toBe(4294967295);
+});
+
+it('treats integer alias same as int', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('integer')))->toBe(2147483647);
+});
+
+it('returns PHP_INT_MAX for bigint regardless of signedness', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('bigint')))->toBe(PHP_INT_MAX)
+        ->and((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('bigint', true)))->toBe(PHP_INT_MAX);
+});
+
+it('is case-insensitive on type name', function (): void {
+    expect((new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('INT', true)))->toBe(4294967295);
+});
+
+it('throws UnsupportedKeyColumnTypeException for non-integer types', function (): void {
+    (new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('varchar'));
+})->throws(UnsupportedKeyColumnTypeException::class);
+
+it('throws UnsupportedKeyColumnTypeException for char (UUID columns must use new_uuid)', function (): void {
+    (new KeyTypeBoundsResolver)->ceilingFor(makeIntCol('char'));
+})->throws(UnsupportedKeyColumnTypeException::class);


### PR DESCRIPTION
## Summary
- Replace user-configured `min`/`max`/`range_min`/`range_max` with type-aware automatic allocation: ceiling derived from PK column data type + unsigned flag (`TINYINT` 127/255, `SMALLINT` 32767/65535, `MEDIUMINT` 8388607/16777215, `INT` 2147483647/4294967295, `BIGINT` `PHP_INT_MAX`).
- New strategy: ascending IDs starting at `MAX(id)+1`, fall back to filling gaps in `[1, MAX(id)]` if upper region exhausted, throw `KeyRemappingExhaustedException` if neither region has room.
- Fixes silent column-type overflow that caused duplicate composite-key errors on narrow PK columns (`SQLSTATE[23000] Duplicate entry '2889387-65535-255' for key 'werkstatt_netz2institution.composite_key'`).
- Pre-1.0.0: legacy YAML keys (`min`/`max`/`range_min`/`range_max`) are hard validation errors — no migration shim.

## Design
Spec: `specs/2026-04-27-key-remapping-auto-bounds.md`
Plan: `docs/superpowers/plans/2026-04-27-key-remapping-auto-bounds.md`
PRD bumped to v0.3: `specs/PRD-cloning-key-remapping.md`

## Key files
- New: `KeyTypeBoundsResolver`, `KeyRemappingExhaustedException`, `UnsupportedKeyColumnTypeException`
- `ColumnSchemaData` gains `unsigned` flag (populated by `SchemaInspector` from `COLUMN_TYPE` for MySQL/MariaDB)
- `KeyRemappingService::allocateIntegerIds()` is the new pure allocator; `generateMappings()` now takes `DatabaseSchemaData`
- Range fields removed from `KeyRemappingTableData`, `ColumnCloningConfigData`, loader, validator, writer, dump

## Test plan
- [x] `KeyTypeBoundsResolverTest` — 13 cases covering signed/unsigned matrix + unsupported type errors
- [x] `KeyRemappingServiceTest` — new allocator: ascending start, gap-fill fallback, exhaustion exception, empty source, signed-int positive-only, source-order preservation
- [x] `CloningYamlValidatorTest` — legacy `range_min`/`range_max` and inline `min`/`max` now produce hard rejection errors
- [x] `CloningYamlLoaderTest`, `CloningYamlWriterTest`, `DumpCommandTest`, `KeyRemappingDtoTest` — range references purged
- [x] Full suite: 493 tests pass, 1410 assertions, type coverage 99.3%, code coverage 76.6%, PHPStan max 0 errors, Pint + Rector clean
- [ ] Manual smoke against the original failing schema (no MySQL fixture available locally — reviewer follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)