### PR TITLE
fix(build): pin libcares + direct tarball URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -97,6 +97,9 @@ jobs:
       # Pin OpenSSL to 3.x. OpenSSL 4.0.0 removed ERR_NUM_ERRORS, which PHP 8.5's
       # openssl extension still references — fresh downloads otherwise grab 4.x and fail to compile.
       OPENSSL_VERSION: '3.6.2'
+      # Pin libcares to a known-good tag. SPC 2.8.4 release-metadata lookup has been
+      # flaky for c-ares/c-ares; pinning + direct URL bypasses the GH releases API path.
+      LIBCARES_VERSION: '1.34.6'
 
     steps:
       - name: Checkout
@@ -129,7 +132,7 @@ jobs:
           path: ./downloads
           # Key by matrix.output so Linux x86_64 and Linux aarch64 don't share a cache.
           # Previously used runner.os only, which collided across the two Linux arches.
-          key: spc-downloads-${{ matrix.output }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-mbregex-v1
+          key: spc-downloads-${{ matrix.output }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-mbregex-cares${{ env.LIBCARES_VERSION }}
 
       - name: Download PHP sources & extensions
         if: steps.spc-downloads-cache.outputs.cache-hit != 'true'
@@ -140,14 +143,15 @@ jobs:
             --with-php=${{ env.PHP_VERSION }} \
             --for-extensions="${{ env.EXTENSIONS }}" \
             --for-libs="${{ env.GD_LIBS }}" \
-            --custom-url="openssl:https://github.com/openssl/openssl/releases/download/openssl-${{ env.OPENSSL_VERSION }}/openssl-${{ env.OPENSSL_VERSION }}.tar.gz"
+            --custom-url="openssl:https://github.com/openssl/openssl/releases/download/openssl-${{ env.OPENSSL_VERSION }}/openssl-${{ env.OPENSSL_VERSION }}.tar.gz" \
+            --custom-url="libcares:https://github.com/c-ares/c-ares/releases/download/v${{ env.LIBCARES_VERSION }}/c-ares-${{ env.LIBCARES_VERSION }}.tar.gz"
 
       - name: Cache SPC build output
         id: spc-build-cache
         uses: actions/cache@v5
         with:
           path: ./buildroot
-          key: spc-build-${{ matrix.output }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-mbregex-v1
+          key: spc-build-${{ matrix.output }}-php${{ env.PHP_VERSION }}-openssl${{ env.OPENSSL_VERSION }}-gd${{ env.GD_LIBS_SLUG }}-mbregex-cares${{ env.LIBCARES_VERSION }}
 
       - name: Compile PHP micro SAPI
         if: steps.spc-build-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- SPC 2.8.4 fails on libcares step: \`failed to find libcares release metadata\` (GH releases API) → fallback path crashes with downloader bug (\`unlink(downloads/): Is a directory\`, \`Argument #3 ($filename) must be of type string, false given\`).
- c-ares/c-ares releases + assets are healthy (verified via API + direct \`docker pull\`-equivalent curl). Root cause looks like an SPC bug in metadata parsing or asset matching, not a c-ares regression.
- Fix: pin \`LIBCARES_VERSION=1.34.6\` and pass \`--custom-url=\"libcares:https://github.com/c-ares/c-ares/releases/download/v.../c-ares-....tar.gz\"\` so SPC bypasses both the API lookup and the buggy fallback.
- Cache key suffix bumped to \`-cares\${LIBCARES_VERSION}\` to evict any partial libcares download from prior failed runs.

## Test plan
- [ ] Workflow_dispatch on this branch — verify all 3 build jobs (linux x86_64, linux aarch64, macos aarch64) pass the libcares download step
- [ ] Verify subsequent build/combine/test stages still succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)