### PR TITLE
feat(cloning:column:edit): support remapping strategy with auto-detected FKs

### DIFF
--- a/app/Commands/Cloning/ColumnEditCommand.php
+++ b/app/Commands/Cloning/ColumnEditCommand.php
@@ -4,10 +4,20 @@ declare(strict_types=1);
 
 namespace App\Commands\Cloning;
 
+use App\Data\ConnectionData;
+use App\Data\Schema\ColumnSchemaData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\TableSchemaData;
 use App\Enums\ExitCode;
+use App\Enums\KeyRemappingStrategy;
+use App\Services\Config\ConfigService;
+use App\Services\Database\DatabaseConnectionService;
+use App\Services\Schema\SchemaInspector;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Storage;
 use LaravelZero\Framework\Commands\Command;
 use Symfony\Component\Yaml\Yaml;
+use Throwable;
 
 class ColumnEditCommand extends Command
 {
@@ -18,7 +28,7 @@ class ColumnEditCommand extends Command
         {file?              : Path to the .cloning.yaml file}
         {--table=           : Table name}
         {--column=          : Column name}
-        {--strategy=        : Strategy to apply (keep, fake, hash, mask, static)}
+        {--strategy=        : Strategy to apply (keep, fake, hash, mask, static, remapping)}
         {--faker-method=    : (fake) Faker method name}
         {--faker-arguments= : (fake) Comma-separated faker arguments}
         {--algorithm=       : (hash) Hash algorithm}
@@ -26,7 +36,8 @@ class ColumnEditCommand extends Command
         {--mask-char=       : (mask) Mask character}
         {--visible-chars=   : (mask) Number of visible characters}
         {--preserve-format  : (mask) Preserve original format}
-        {--value=           : (static) Static replacement value}';
+        {--value=           : (static) Static replacement value}
+        {--remapping-use=   : (remapping) random_integer | new_uuid}';
 
     /**
      * @var string
@@ -78,8 +89,21 @@ class ColumnEditCommand extends Command
                     ['name' => 'value', 'label' => 'Static value', 'type' => 'string', 'default' => ''],
                 ],
             ],
+            'remapping' => [
+                'label' => 'Remapping',
+                'description' => 'Replace primary key values; foreign keys auto-detected from the source schema.',
+                'parameters' => [
+                    ['name' => 'remapping_use', 'label' => 'Remapping mode', 'type' => 'choice', 'default' => 'random_integer'],
+                ],
+            ],
         ];
     }
+
+    /** @var array<string, string> */
+    private const array REMAPPING_USE_LABELS = [
+        'random_integer' => 'Random integer — auto-bounded by column type ceiling',
+        'new_uuid' => 'New UUID (UUIDv7)',
+    ];
 
     /** @var list<string> */
     private const array FAKER_METHODS = [
@@ -126,8 +150,11 @@ class ColumnEditCommand extends Command
     /** @var list<string> */
     private const array HASH_ALGORITHMS = ['sha256', 'sha512', 'md5', 'sha1'];
 
-    public function handle(): int
-    {
+    public function handle(
+        ConfigService $configService,
+        DatabaseConnectionService $connector,
+        SchemaInspector $inspector,
+    ): int {
         // ─── Resolve file ──────────────────────────────────────────────────
         $fileArg = $this->argument('file');
         $filePath = is_string($fileArg) && $fileArg !== '' ? $fileArg : null;
@@ -271,6 +298,14 @@ class ColumnEditCommand extends Command
 
         $definition = $definitions[$strategyKey];
 
+        // Validate --remapping-use flag value upfront (if provided).
+        $useFlag = $this->option('remapping-use');
+        if ($strategyKey === 'remapping' && is_string($useFlag) && $useFlag !== '' && ! in_array($useFlag, KeyRemappingStrategy::values(), true)) {
+            $this->error(sprintf("Unknown remapping use: '%s'. Valid: %s", $useFlag, implode(', ', KeyRemappingStrategy::values())));
+
+            return ExitCode::ValidationError->value;
+        }
+
         // ─── Collect parameters ────────────────────────────────────────────
         /** @var array<string, mixed> $newConfig */
         $newConfig = ['strategy' => $strategyKey];
@@ -295,6 +330,30 @@ class ColumnEditCommand extends Command
             }
         }
 
+        // ─── Remapping: resolve source schema, validate PK, detect FKs ─────
+        /** @var list<array{table: string, column: string, self_referential: bool}> $remappingForeignKeys */
+        $remappingForeignKeys = [];
+
+        if ($strategyKey === 'remapping') {
+            $connectionName = is_string($data['connection'] ?? null) ? $data['connection'] : '';
+            $remappingContext = $this->resolveRemappingContext(
+                connectionName: $connectionName,
+                tableName: $tableName,
+                columnName: $columnName,
+                configService: $configService,
+                connector: $connector,
+                inspector: $inspector,
+            );
+
+            if ($remappingContext['error'] !== null) {
+                $this->error($remappingContext['error']);
+
+                return ExitCode::ValidationError->value;
+            }
+
+            $remappingForeignKeys = $remappingContext['foreignKeys'];
+        }
+
         // ─── Summary ──────────────────────────────────────────────────────
         $this->line('');
         $rows = [['Table', $tableName], ['Column', $columnName], ['Strategy', $definition['label']]];
@@ -307,6 +366,20 @@ class ColumnEditCommand extends Command
                     : (is_bool($paramValue) ? ($paramValue ? 'true' : 'false') : (is_scalar($paramValue) ? (string) $paramValue : ''));
                 $rows[] = [$param['label'], $display];
             }
+        }
+
+        if ($strategyKey === 'remapping') {
+            $rows[] = ['Foreign keys (auto-detected)', $remappingForeignKeys === []
+                ? '— none —'
+                : implode(', ', array_map(
+                    static fn (array $fk): string => sprintf(
+                        '%s.%s%s',
+                        $fk['table'],
+                        $fk['column'],
+                        $fk['self_referential'] ? ' (self)' : '',
+                    ),
+                    $remappingForeignKeys,
+                ))];
         }
 
         /** @var string $strategyKey */
@@ -345,6 +418,18 @@ class ColumnEditCommand extends Command
             $newConfig['visible_chars'] = is_numeric($visibleCharsVal) ? (int) $visibleCharsVal : 0;
         }
 
+        // Reshape remapping config into arguments-list form (mirrors cloning:dump output)
+        if ($strategyKey === 'remapping') {
+            $use = is_string($newConfig['remapping_use'] ?? null) ? $newConfig['remapping_use'] : 'random_integer';
+            $newConfig = [
+                'strategy' => 'remapping',
+                'arguments' => [
+                    ['use' => $use],
+                    ['foreign_keys' => $remappingForeignKeys],
+                ],
+            ];
+        }
+
         $columns[$columnName] = $newConfig;
         $tableConfig['columns'] = $columns;
         /** @var array<string, mixed> $dataTables */
@@ -352,7 +437,7 @@ class ColumnEditCommand extends Command
         $dataTables[$tableName] = $tableConfig;
         $data['tables'] = $dataTables;
 
-        $yaml = Yaml::dump($data, 6, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK);
+        $yaml = Yaml::dump($data, 6, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_EMPTY_ARRAY_AS_SEQUENCE);
         Storage::disk('local')->put($filePath, $yaml);
 
         $this->info(sprintf('Updated %s.%s → strategy: %s in %s', $tableName, $columnName, $strategyKey, $filePath));
@@ -425,7 +510,117 @@ class ColumnEditCommand extends Command
             return is_string($chosen) ? $chosen : $param['default'];
         }
 
+        if ($param['name'] === 'remapping_use') {
+            $useValues = array_keys(self::REMAPPING_USE_LABELS);
+            $useLabels = array_values(self::REMAPPING_USE_LABELS);
+            $defaultIdx = (int) array_search($param['default'], $useValues, true);
+            $chosen = $this->choice($param['label'], $useLabels, $defaultIdx);
+            $key = is_string($chosen) ? array_search($chosen, self::REMAPPING_USE_LABELS, true) : false;
+
+            return is_string($key) ? $key : $param['default'];
+        }
+
         return $param['default'];
+    }
+
+    /**
+     * Resolve source schema for a remapping column: validate the column is a primary key and
+     * auto-detect reverse foreign keys (other tables whose FKs reference this PK).
+     *
+     * @return array{error: ?string, foreignKeys: list<array{table: string, column: string, self_referential: bool}>}
+     */
+    private function resolveRemappingContext(
+        string $connectionName,
+        string $tableName,
+        string $columnName,
+        ConfigService $configService,
+        DatabaseConnectionService $connector,
+        SchemaInspector $inspector,
+    ): array {
+        if ($connectionName === '') {
+            $this->warn('  Source connection unknown (YAML missing top-level "connection") — writing foreign_keys: [] and skipping primary-key validation.');
+
+            return ['error' => null, 'foreignKeys' => []];
+        }
+
+        $connection = $configService->getConnection($connectionName);
+
+        if (! $connection instanceof ConnectionData) {
+            $this->warn(sprintf("  Source connection '%s' not found in clonio.json — writing foreign_keys: [] and skipping primary-key validation.", $connectionName));
+
+            return ['error' => null, 'foreignKeys' => []];
+        }
+
+        try {
+            $connName = $connector->open($connection);
+
+            try {
+                $schema = $inspector->inspect($connection);
+            } finally {
+                DB::purge($connName);
+            }
+        } catch (Throwable $throwable) {
+            $this->warn(sprintf('  Source connection unreachable (%s) — writing foreign_keys: [] and skipping primary-key validation.', $throwable->getMessage()));
+
+            return ['error' => null, 'foreignKeys' => []];
+        }
+
+        $table = $schema->getTable($tableName);
+
+        if (! $table instanceof TableSchemaData) {
+            return [
+                'error' => sprintf("Table '%s' does not exist in source schema for connection '%s'.", $tableName, $connectionName),
+                'foreignKeys' => [],
+            ];
+        }
+
+        $column = array_find($table->columns, static fn (ColumnSchemaData $col): bool => $col->name === $columnName);
+
+        if (! $column instanceof ColumnSchemaData) {
+            return [
+                'error' => sprintf("Column '%s' does not exist on table '%s' in source schema.", $columnName, $tableName),
+                'foreignKeys' => [],
+            ];
+        }
+
+        if (! $column->isPrimary) {
+            return [
+                'error' => sprintf("Column '%s.%s' is not a primary key in source schema — remapping requires a primary-key column.", $tableName, $columnName),
+                'foreignKeys' => [],
+            ];
+        }
+
+        return ['error' => null, 'foreignKeys' => $this->detectReverseForeignKeys($schema, $tableName, $columnName)];
+    }
+
+    /**
+     * Scan every table for FK columns referencing <tableName>.<columnName>.
+     *
+     * @return list<array{table: string, column: string, self_referential: bool}>
+     */
+    private function detectReverseForeignKeys(DatabaseSchemaData $schema, string $tableName, string $columnName): array
+    {
+        $foreignKeys = [];
+
+        foreach ($schema->tables as $sourceTable) {
+            foreach ($sourceTable->foreignKeys as $fk) {
+                if ($fk->referencedTable !== $tableName) {
+                    continue;
+                }
+
+                if ($fk->referencedColumn !== $columnName) {
+                    continue;
+                }
+
+                $foreignKeys[] = [
+                    'table' => $sourceTable->name,
+                    'column' => $fk->columnName,
+                    'self_referential' => $sourceTable->name === $tableName,
+                ];
+            }
+        }
+
+        return $foreignKeys;
     }
 
     private function askString(string $question, string $default): string

--- a/docs/commands/cloning-column-edit.md
+++ b/docs/commands/cloning-column-edit.md
@@ -31,6 +31,7 @@ When run without flags, the command walks through each step interactively:
 | `hash` | Replace with a one-way hash of the original value. Useful for passwords and secrets. |
 | `mask` | Partially mask the value, preserving a configurable number of visible characters. |
 | `static` | Replace every value with a fixed string. |
+| `remapping` | Replace primary-key values; foreign keys auto-detected from the live source schema. |
 
 ### `fake` Parameters
 
@@ -90,6 +91,33 @@ Argument reference for methods that accept parameters:
 |-----------|--------|-------------|
 | Value | `--value=` | The fixed string to replace every value with |
 
+### `remapping` Parameters
+
+| Parameter | Option | Description |
+|-----------|--------|-------------|
+| Remapping mode | `--remapping-use=` | `random_integer` (auto-bounded by column type ceiling) or `new_uuid` (UUIDv7) |
+
+The command opens the source connection declared at the YAML top-level (`connection:`), inspects the live schema, and:
+
+1. **Validates** that the chosen column is a primary key on the source table. If it is not, the command exits with code `4` and the YAML is left untouched.
+2. **Auto-detects** every foreign key in the source database that references `<table>.<column>`. The detected list is written into the `arguments[].foreign_keys` block — overwriting any prior list. Self-references (FK on the same table) are emitted with `self_referential: true`.
+
+The output structure mirrors `cloning:dump`:
+
+```yaml
+columns:
+  id:
+    strategy: remapping
+    arguments:
+      - use: random_integer
+      - foreign_keys:
+          - table: posts
+            column: user_id
+            self_referential: false
+```
+
+If the source connection cannot be reached (config missing, host unreachable, etc.), the command prints a warning, **skips** primary-key validation, and writes an empty `foreign_keys: []`. Re-run the command once the connection is available, or hand-edit the FK list, to populate the relationships.
+
 ## Options
 
 | Option | Description |
@@ -97,7 +125,8 @@ Argument reference for methods that accept parameters:
 | `file` | Path to the `.cloning.yaml` file (argument, optional) |
 | `--table=` | Table name |
 | `--column=` | Column name |
-| `--strategy=` | Strategy to apply: `keep`, `fake`, `hash`, `mask`, `static` |
+| `--strategy=` | Strategy to apply: `keep`, `fake`, `hash`, `mask`, `static`, `remapping` |
+| `--remapping-use=` | (`remapping`) `random_integer` or `new_uuid` |
 
 ## Exit Codes
 
@@ -131,4 +160,13 @@ clonio cloning:column:edit production-db.cloning.yaml \
 # Non-interactive: replace all values with a static string
 clonio cloning:column:edit production-db.cloning.yaml \
   --table=users --column=bio --strategy=static --value=redacted
+
+# Non-interactive: enable random-integer key remapping for users.id
+# (foreign keys auto-detected from the source schema)
+clonio cloning:column:edit production-db.cloning.yaml \
+  --table=users --column=id --strategy=remapping --remapping-use=random_integer
+
+# Non-interactive: enable UUIDv7 key remapping
+clonio cloning:column:edit production-db.cloning.yaml \
+  --table=users --column=id --strategy=remapping --remapping-use=new_uuid
 ```

--- a/tests/Feature/Commands/Cloning/ColumnEditCommandTest.php
+++ b/tests/Feature/Commands/Cloning/ColumnEditCommandTest.php
@@ -2,8 +2,92 @@
 
 declare(strict_types=1);
 
+use App\Data\ConnectionData;
+use App\Data\Schema\ColumnSchemaData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\ForeignKeyData;
+use App\Data\Schema\TableSchemaData;
+use App\Enums\DatabaseConnectionType;
 use App\Enums\ExitCode;
+use App\Services\Config\ConfigService;
+use App\Services\Database\DatabaseConnectionService;
+use App\Services\Schema\SchemaInspector;
 use Illuminate\Support\Facades\Storage;
+
+function makeRemappingConnection(): ConnectionData
+{
+    return new ConnectionData(
+        name: 'production-db',
+        type: DatabaseConnectionType::Sqlite,
+        host: null,
+        port: null,
+        database: ':memory:',
+        schema: null,
+        username: null,
+        password: '',
+        isProduction: true,
+    );
+}
+
+/**
+ * @param  list<array{name: string, type: string, isPrimary: bool, unsigned?: bool}>  $columns
+ * @param  list<array{columnName: string, referencedTable: string, referencedColumn: string}>  $foreignKeys
+ */
+function makeRemappingTable(string $name, array $columns, array $foreignKeys = []): TableSchemaData
+{
+    return new TableSchemaData(
+        name: $name,
+        columns: array_map(
+            static fn (array $col): ColumnSchemaData => new ColumnSchemaData(
+                name: $col['name'],
+                type: $col['type'],
+                nullable: false,
+                default: null,
+                isPrimary: $col['isPrimary'],
+                unsigned: $col['unsigned'] ?? false,
+            ),
+            $columns,
+        ),
+        foreignKeys: array_map(
+            static fn (array $fk): ForeignKeyData => new ForeignKeyData(
+                columnName: $fk['columnName'],
+                referencedTable: $fk['referencedTable'],
+                referencedColumn: $fk['referencedColumn'],
+            ),
+            $foreignKeys,
+        ),
+    );
+}
+
+/**
+ * @param  list<TableSchemaData>  $tables
+ */
+function bindRemappingDeps(array $tables, ?Throwable $openThrows = null): void
+{
+    $configMock = Mockery::mock(ConfigService::class);
+    $configMock->shouldReceive('getConnection')
+        ->with('production-db')
+        ->andReturn(makeRemappingConnection());
+    $configMock->shouldReceive('getConnection')
+        ->andReturn(null);
+
+    app()->instance(ConfigService::class, $configMock);
+
+    $connectorMock = Mockery::mock(DatabaseConnectionService::class);
+    if ($openThrows instanceof Throwable) {
+        $connectorMock->shouldReceive('open')->andThrow($openThrows);
+    } else {
+        $connectorMock->shouldReceive('open')->andReturn('source');
+    }
+
+    app()->instance(DatabaseConnectionService::class, $connectorMock);
+
+    $inspectorMock = Mockery::mock(SchemaInspector::class);
+    $inspectorMock->shouldReceive('inspect')
+        ->andReturn(new DatabaseSchemaData('test', $tables));
+
+    app()->instance(SchemaInspector::class, $inspectorMock);
+}
 
 function makeTestCloningYaml(): string
 {
@@ -231,4 +315,182 @@ it('shows argument hint for methods that accept arguments', function (): void {
 
     $content = Storage::disk('local')->get('test.cloning.yaml');
     expect($content)->toContain('faker_method: numberBetween');
+});
+
+it('updates column to remapping strategy with auto-detected foreign keys', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('test.cloning.yaml', makeTestCloningYaml());
+
+    bindRemappingDeps([
+        makeRemappingTable('users', [
+            ['name' => 'id', 'type' => 'int', 'isPrimary' => true, 'unsigned' => true],
+            ['name' => 'email', 'type' => 'varchar', 'isPrimary' => false],
+        ]),
+        makeRemappingTable('posts', [
+            ['name' => 'id', 'type' => 'int', 'isPrimary' => true],
+            ['name' => 'user_id', 'type' => 'int', 'isPrimary' => false],
+        ], [
+            ['columnName' => 'user_id', 'referencedTable' => 'users', 'referencedColumn' => 'id'],
+        ]),
+    ]);
+
+    $this->artisan('cloning:column:edit', [
+        'file' => 'test.cloning.yaml',
+        '--table' => 'users',
+        '--column' => 'id',
+        '--strategy' => 'remapping',
+        '--remapping-use' => 'random_integer',
+    ])
+        ->expectsConfirmation('Apply this change?', 'yes')
+        ->expectsOutputToContain('Updated users.id')
+        ->assertExitCode(ExitCode::Success->value);
+
+    $content = Storage::disk('local')->get('test.cloning.yaml');
+    expect($content)->toContain('strategy: remapping');
+    expect($content)->toContain('use: random_integer');
+    expect($content)->toContain('table: posts');
+    expect($content)->toContain('column: user_id');
+    expect($content)->toContain('self_referential: false');
+});
+
+it('updates column to remapping strategy with new_uuid use', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('test.cloning.yaml', makeTestCloningYaml());
+
+    bindRemappingDeps([
+        makeRemappingTable('users', [
+            ['name' => 'id', 'type' => 'uuid', 'isPrimary' => true],
+        ]),
+    ]);
+
+    $this->artisan('cloning:column:edit', [
+        'file' => 'test.cloning.yaml',
+        '--table' => 'users',
+        '--column' => 'id',
+        '--strategy' => 'remapping',
+        '--remapping-use' => 'new_uuid',
+    ])
+        ->expectsConfirmation('Apply this change?', 'yes')
+        ->assertExitCode(ExitCode::Success->value);
+
+    $content = Storage::disk('local')->get('test.cloning.yaml');
+    expect($content)->toContain('use: new_uuid');
+    expect($content)->toContain('foreign_keys: []');
+});
+
+it('detects self-referential foreign keys for remapping', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('test.cloning.yaml', makeTestCloningYaml());
+
+    bindRemappingDeps([
+        makeRemappingTable('users', [
+            ['name' => 'id', 'type' => 'int', 'isPrimary' => true],
+            ['name' => 'parent_id', 'type' => 'int', 'isPrimary' => false],
+        ], [
+            ['columnName' => 'parent_id', 'referencedTable' => 'users', 'referencedColumn' => 'id'],
+        ]),
+    ]);
+
+    $this->artisan('cloning:column:edit', [
+        'file' => 'test.cloning.yaml',
+        '--table' => 'users',
+        '--column' => 'id',
+        '--strategy' => 'remapping',
+        '--remapping-use' => 'random_integer',
+    ])
+        ->expectsConfirmation('Apply this change?', 'yes')
+        ->assertExitCode(ExitCode::Success->value);
+
+    $content = Storage::disk('local')->get('test.cloning.yaml');
+    expect($content)->toContain('column: parent_id');
+    expect($content)->toContain('self_referential: true');
+});
+
+it('hard-fails when target column is not a primary key', function (): void {
+    Storage::fake('local');
+    $original = makeTestCloningYaml();
+    Storage::disk('local')->put('test.cloning.yaml', $original);
+
+    bindRemappingDeps([
+        makeRemappingTable('users', [
+            ['name' => 'id', 'type' => 'int', 'isPrimary' => true],
+            ['name' => 'email', 'type' => 'varchar', 'isPrimary' => false],
+        ]),
+    ]);
+
+    $this->artisan('cloning:column:edit', [
+        'file' => 'test.cloning.yaml',
+        '--table' => 'users',
+        '--column' => 'email',
+        '--strategy' => 'remapping',
+        '--remapping-use' => 'random_integer',
+    ])
+        ->expectsOutputToContain("'users.email' is not a primary key")
+        ->assertExitCode(ExitCode::ValidationError->value);
+
+    expect(Storage::disk('local')->get('test.cloning.yaml'))->toBe($original);
+});
+
+it('rejects unknown --remapping-use value', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('test.cloning.yaml', makeTestCloningYaml());
+
+    $this->artisan('cloning:column:edit', [
+        'file' => 'test.cloning.yaml',
+        '--table' => 'users',
+        '--column' => 'id',
+        '--strategy' => 'remapping',
+        '--remapping-use' => 'bogus',
+    ])
+        ->expectsOutputToContain("Unknown remapping use: 'bogus'")
+        ->assertExitCode(ExitCode::ValidationError->value);
+});
+
+it('falls back to empty foreign_keys when source connection is unreachable', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('test.cloning.yaml', makeTestCloningYaml());
+
+    bindRemappingDeps([], new RuntimeException('Connection refused'));
+
+    $this->artisan('cloning:column:edit', [
+        'file' => 'test.cloning.yaml',
+        '--table' => 'users',
+        '--column' => 'id',
+        '--strategy' => 'remapping',
+        '--remapping-use' => 'random_integer',
+    ])
+        ->expectsOutputToContain('Source connection unreachable')
+        ->expectsConfirmation('Apply this change?', 'yes')
+        ->assertExitCode(ExitCode::Success->value);
+
+    $content = Storage::disk('local')->get('test.cloning.yaml');
+    expect($content)->toContain('strategy: remapping');
+    expect($content)->toContain('use: random_integer');
+    expect($content)->toContain('foreign_keys: []');
+});
+
+it('falls back to empty foreign_keys when YAML connection name is unknown to clonio.json', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put(
+        'test.cloning.yaml',
+        str_replace('connection: production-db', 'connection: missing-db', makeTestCloningYaml())
+    );
+
+    $configMock = Mockery::mock(ConfigService::class);
+    $configMock->shouldReceive('getConnection')->with('missing-db')->andReturn(null);
+    $this->app->instance(ConfigService::class, $configMock);
+
+    $this->artisan('cloning:column:edit', [
+        'file' => 'test.cloning.yaml',
+        '--table' => 'users',
+        '--column' => 'id',
+        '--strategy' => 'remapping',
+        '--remapping-use' => 'random_integer',
+    ])
+        ->expectsOutputToContain("Source connection 'missing-db' not found in clonio.json")
+        ->expectsConfirmation('Apply this change?', 'yes')
+        ->assertExitCode(ExitCode::Success->value);
+
+    $content = Storage::disk('local')->get('test.cloning.yaml');
+    expect($content)->toContain('foreign_keys: []');
 });


### PR DESCRIPTION
## Summary

- Adds the `remapping` column strategy to `cloning:column:edit`, matching the YAML shape emitted by `cloning:dump` (`strategy: remapping` + `arguments: [{use: ...}, {foreign_keys: [...]}]`)
- Opens the source connection declared at the YAML top-level (`connection:`) via `ConfigService` + `DatabaseConnectionService` + `SchemaInspector` to validate the target column is a primary key (hard-fail with `ValidationError` otherwise) and auto-detect every reverse foreign key. Self-FKs are marked `self_referential: true`. Existing FK lists are overwritten with fresh detection.
- New flag `--remapping-use=random_integer|new_uuid` (default `random_integer`); descriptive picker labels in interactive mode.
- Connection unreachable / config missing → warns, writes `foreign_keys: []`, skips PK guard so the editor remains usable offline.
- Docs (`docs/commands/cloning-column-edit.md`) updated with the new strategy section, examples, and option table.

Closes #102.

## Test plan

- [x] `composer test` (500 tests / 1441 assertions, type coverage 99.3%, PHPStan max clean, Pint + Rector clean)
- [x] 7 new feature tests cover: detected FKs, `new_uuid` with empty FKs, self-referential FK detection, non-PK column hard-fail, unknown `--remapping-use` rejection, connection-unreachable fallback, unknown YAML connection-name fallback
- [ ] Smoke-tested manually against a sample `.cloning.yaml` + live MySQL source (run `cloning:column:edit ... --strategy=remapping --remapping-use=random_integer`, verify YAML matches `cloning:dump` output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)