### PR TITLE
feat(audit): Summary & Integrity recap with source/target connection details

### DIFF
--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -502,7 +502,7 @@ class RunCommand extends Command
             /**
              * @var array{auditArtefacts: array<string, string>, templateVars: array<string, string>, processLogContent: string} $auditPayload
              */
-            $auditPayload = $step->run('Generating audit log', function () use ($builder, $renderer, $signer, $config, $result, $targetName, $startedAt, $finishedAt, $yamlFileName, $runLog): array {
+            $auditPayload = $step->run('Generating audit log', function () use ($builder, $renderer, $signer, $config, $result, $targetName, $startedAt, $finishedAt, $yamlFileName, $runLog, $sourceConnection, $targetConnection): array {
                 $auditRecord = $builder->build(
                     config: $config,
                     result: $result,
@@ -510,6 +510,8 @@ class RunCommand extends Command
                     startedAt: $startedAt,
                     finishedAt: $finishedAt,
                     yamlFileName: $yamlFileName,
+                    sourceConnectionData: $sourceConnection,
+                    targetConnectionData: $targetConnection,
                 );
 
                 [$canonicalJson, $contentHash, $hmacSignature] = $signer->sign($auditRecord);

--- a/app/Data/Audit/AuditRecordData.php
+++ b/app/Data/Audit/AuditRecordData.php
@@ -12,6 +12,8 @@ final readonly class AuditRecordData
     /**
      * @param  list<AuditTableRecordData>  $tables
      * @param  list<string>  $channels
+     * @param  array{name: string, type: string, host: ?string, port: ?int, database: ?string, schema: ?string, username: ?string}  $sourceConnectionDetails
+     * @param  array{name: string, type: string, host: ?string, port: ?int, database: ?string, schema: ?string, username: ?string}  $targetConnectionDetails
      */
     public function __construct(
         public string $clonioVersion,
@@ -28,5 +30,7 @@ final readonly class AuditRecordData
         public array $channels,
         public string $contentHash,
         public string $hmacSignature,
+        public array $sourceConnectionDetails,
+        public array $targetConnectionDetails,
     ) {}
 }

--- a/app/Services/Audit/AuditLogBuilder.php
+++ b/app/Services/Audit/AuditLogBuilder.php
@@ -11,6 +11,7 @@ use App\Data\Cloning\CloningConfigData;
 use App\Data\Cloning\RunResultData;
 use App\Data\Cloning\TableCloningConfigData;
 use App\Data\Cloning\TableRunStatus;
+use App\Data\ConnectionData;
 use DateTimeImmutable;
 
 class AuditLogBuilder
@@ -24,6 +25,8 @@ class AuditLogBuilder
         DateTimeImmutable $startedAt,
         DateTimeImmutable $finishedAt,
         string $yamlFileName,
+        ?ConnectionData $sourceConnectionData = null,
+        ?ConnectionData $targetConnectionData = null,
     ): AuditRecordData {
         $auditTables = [];
 
@@ -68,6 +71,9 @@ class AuditLogBuilder
         $rawVersion = config('app.version', '1.0.0');
         $clonioVersion = is_string($rawVersion) ? $rawVersion : '1.0.0';
 
+        $sourceDetails = $this->projectConnectionDetails($config->connectionName, $sourceConnectionData);
+        $targetDetails = $this->projectConnectionDetails($targetConnection, $targetConnectionData);
+
         // Create a placeholder record (without hash/sig) to sign
         $placeholder = new AuditRecordData(
             clonioVersion: $clonioVersion,
@@ -84,6 +90,8 @@ class AuditLogBuilder
             channels: [],
             contentHash: '',
             hmacSignature: '',
+            sourceConnectionDetails: $sourceDetails,
+            targetConnectionDetails: $targetDetails,
         );
 
         [, $contentHash, $hmacSignature] = $this->signer->sign($placeholder);
@@ -103,6 +111,39 @@ class AuditLogBuilder
             channels: [],
             contentHash: $contentHash,
             hmacSignature: $hmacSignature,
+            sourceConnectionDetails: $sourceDetails,
+            targetConnectionDetails: $targetDetails,
         );
+    }
+
+    /**
+     * Project a ConnectionData into a password-free details array suitable for the audit record.
+     * Returns a stub array with only the connection name when no ConnectionData is provided.
+     *
+     * @return array{name: string, type: string, host: ?string, port: ?int, database: ?string, schema: ?string, username: ?string}
+     */
+    private function projectConnectionDetails(string $name, ?ConnectionData $connection): array
+    {
+        if (! $connection instanceof ConnectionData) {
+            return [
+                'name' => $name,
+                'type' => '',
+                'host' => null,
+                'port' => null,
+                'database' => null,
+                'schema' => null,
+                'username' => null,
+            ];
+        }
+
+        return [
+            'name' => $connection->name,
+            'type' => $connection->type->value,
+            'host' => $connection->host,
+            'port' => $connection->port,
+            'database' => $connection->database,
+            'schema' => $connection->schema,
+            'username' => $connection->username,
+        ];
     }
 }

--- a/app/Services/Audit/AuditLogRenderer.php
+++ b/app/Services/Audit/AuditLogRenderer.php
@@ -63,6 +63,9 @@ class AuditLogRenderer
         $totalRowsTransferred = number_format($record->totalRowsTransferred, 0, '.', ' ');
         $totalRowsSkipped = number_format($record->totalRowsSkipped, 0, '.', ' ');
 
+        $sourceConnCard = $this->renderConnectionCard('Source', $record->sourceConnectionDetails);
+        $targetConnCard = $this->renderConnectionCard('Target', $record->targetConnectionDetails);
+
         $escapedCanonicalJson = htmlspecialchars($canonicalJson, ENT_NOQUOTES);
 
         return <<<HTML
@@ -95,9 +98,15 @@ class AuditLogRenderer
 
   .kpi { width: 100%; border-collapse: separate; border-spacing: 3mm 0; margin-bottom: 6mm; margin-left: -3mm; margin-right: -3mm; }
   .kpi td { width: 25%; background: #f8fafc; border: 1px solid #e2e8f0; padding: 4mm; vertical-align: top; border-radius: 2mm; }
+  .kpi.kpi-3 td { width: 33.33%; }
   .kpi .kpi-label { font-size: 8pt; color: #64748b; text-transform: uppercase; letter-spacing: 0.1em; font-weight: bold; }
   .kpi .kpi-value { font-size: 18pt; color: #0f172a; font-weight: bold; margin-top: 2mm; letter-spacing: -0.02em; }
   .kpi .kpi-sub { font-size: 8pt; color: #94a3b8; margin-top: 1mm; }
+
+  .conn-grid { width: 100%; border-collapse: separate; border-spacing: 3mm 0; margin: 0 -3mm 4mm -3mm; }
+  .conn-grid td { width: 50%; background: #f8fafc; border: 1px solid #e2e8f0; padding: 4mm 5mm; vertical-align: top; border-radius: 2mm; }
+  .conn-grid .conn-eyebrow { font-size: 8pt; color: #6366f1; text-transform: uppercase; letter-spacing: 0.12em; font-weight: bold; }
+  .conn-grid .conn-name { font-size: 13pt; color: #0f172a; font-weight: bold; margin: 1mm 0 3mm 0; letter-spacing: -0.01em; }
 
   h2 { font-size: 13pt; color: #0f172a; margin: 7mm 0 3mm 0; font-weight: bold; }
   h2.page-break { page-break-before: always; break-before: page; }
@@ -191,13 +200,41 @@ class AuditLogRenderer
   <tbody>{$tableRows}</tbody>
 </table>
 
-<h2>PII transformations <span class="h2-count">· {$piiColumnCount}</span></h2>
+<h2 class="page-break">PII transformations <span class="h2-count">· {$piiColumnCount}</span></h2>
 <table class="data">
   <thead><tr><th>Table</th><th>Column</th><th>Strategy</th></tr></thead>
   <tbody>{$piiRows}</tbody>
 </table>
 
-<h2 class="page-break">Integrity</h2>
+<h2 class="page-break">Summary &amp; Integrity</h2>
+
+<table class="conn-grid">
+  <tr>
+    {$sourceConnCard}
+    {$targetConnCard}
+  </tr>
+</table>
+
+<table class="kpi kpi-3">
+  <tr>
+    <td>
+      <div class="kpi-label">Rows transferred</div>
+      <div class="kpi-value">{$totalRowsTransferred}</div>
+      <div class="kpi-sub">across {$tableCount} tables</div>
+    </td>
+    <td>
+      <div class="kpi-label">PII columns</div>
+      <div class="kpi-value">{$piiColumnCount}</div>
+      <div class="kpi-sub">anonymised</div>
+    </td>
+    <td>
+      <div class="kpi-label">Duration</div>
+      <div class="kpi-value">{$duration}</div>
+      <div class="kpi-sub">wall-clock</div>
+    </td>
+  </tr>
+</table>
+
 <div class="integrity-card">
   <div class="label">SHA-256 content hash</div>
   <div class="hash">{$contentHash}</div>
@@ -208,6 +245,46 @@ class AuditLogRenderer
 <script type="application/json" id="audit-data">{$escapedCanonicalJson}</script>
 </body>
 </html>
+HTML;
+    }
+
+    /**
+     * Render a single source/target connection card for the Summary & Integrity section.
+     *
+     * @param  array{name: string, type: string, host: ?string, port: ?int, database: ?string, schema: ?string, username: ?string}  $details
+     */
+    private function renderConnectionCard(string $eyebrow, array $details): string
+    {
+        $name = htmlspecialchars($details['name']);
+        $type = $details['type'] !== '' ? htmlspecialchars($details['type']) : '—';
+
+        $hostPort = $details['host'] !== null && $details['host'] !== ''
+            ? htmlspecialchars($details['host']).($details['port'] !== null ? ':'.$details['port'] : '')
+            : '—';
+
+        $database = $details['database'] !== null && $details['database'] !== ''
+            ? htmlspecialchars($details['database'])
+            : '—';
+
+        $username = $details['username'] !== null && $details['username'] !== ''
+            ? htmlspecialchars($details['username'])
+            : '—';
+
+        $schemaRow = $details['schema'] !== null && $details['schema'] !== ''
+            ? sprintf('<tr><td class="label">Schema</td><td class="value">%s</td></tr>', htmlspecialchars($details['schema']))
+            : '';
+
+        return <<<HTML
+<td>
+      <div class="conn-eyebrow">{$eyebrow}</div>
+      <div class="conn-name">{$name}</div>
+      <table class="meta-table">
+        <tr><td class="label">Type</td><td class="value">{$type}</td></tr>
+        <tr><td class="label">Host</td><td class="value">{$hostPort}</td></tr>
+        <tr><td class="label">Database</td><td class="value">{$database}</td></tr>{$schemaRow}
+        <tr><td class="label">Username</td><td class="value">{$username}</td></tr>
+      </table>
+    </td>
 HTML;
     }
 

--- a/specs/PRD-audit-delivery.md
+++ b/specs/PRD-audit-delivery.md
@@ -111,10 +111,15 @@ The audit log HTML document contains the following sections:
 - List of tables with at least one transformation
 - Statement: "All PII columns configured for transformation in this run were processed."
 
-### 4.5 Integrity Section
-- Document hash (SHA-256 of canonical JSON)
-- HMAC-SHA256 signature (truncated to first 16 chars for display; full value in `.sig` file)
-- Verification instruction: `clonio cloning:verify-audit <file>`
+### 4.5 Summary & Integrity Section
+Always rendered on its own page (forced page break before the heading).
+
+- **Connection cards** — side-by-side cards for source and target showing `name`, `type`, `host:port`, `database`, optional `schema`, and `username`. **Passwords are never rendered or stored in the audit record.**
+- **Recap KPI strip** — duplicates the cover-page summary so a reader landing on the last page sees the run's key numbers without flipping back: rows transferred (with table count), PII columns anonymised, and total duration.
+- **Integrity card** (dark) — document hash (SHA-256 of canonical JSON) + HMAC-SHA256 signature (full value in the `.sig` artefact).
+- Verification instruction: `clonio cloning:verify-audit <file>`.
+
+The PII transformations section likewise begins on its own page (`<h2 class="page-break">PII transformations</h2>`) so the table is never split across the cover page.
 
 ---
 
@@ -422,6 +427,10 @@ final readonly class AuditRecordData
         public array $channels,
         public string $contentHash,       // SHA-256 of canonical JSON
         public string $hmacSignature,     // HMAC-SHA256(contentHash, APP_KEY)
+        // Source / target connection details — name/type/host/port/database/schema/username only.
+        // Password is intentionally omitted so the audit trail can be safely shared.
+        public array $sourceConnectionDetails,
+        public array $targetConnectionDetails,
     ) {}
 }
 ```

--- a/tests/Unit/Services/Audit/AuditLogBuilderTest.php
+++ b/tests/Unit/Services/Audit/AuditLogBuilderTest.php
@@ -10,8 +10,40 @@ use App\Data\Cloning\TableCloningConfigData;
 use App\Data\Cloning\TableRowConfigData;
 use App\Data\Cloning\TableRunResultData;
 use App\Data\Cloning\TableRunStatus;
+use App\Data\ConnectionData;
+use App\Enums\DatabaseConnectionType;
 use App\Services\Audit\AuditLogBuilder;
 use App\Services\Audit\AuditLogSigner;
+
+function makeBuilderSourceConnection(): ConnectionData
+{
+    return new ConnectionData(
+        name: 'production-db',
+        type: DatabaseConnectionType::Mysql,
+        host: 'db.prod.io',
+        port: 3306,
+        database: 'mydb',
+        schema: null,
+        username: 'root',
+        password: 'secret',
+        isProduction: true,
+    );
+}
+
+function makeBuilderTargetConnection(): ConnectionData
+{
+    return new ConnectionData(
+        name: 'staging',
+        type: DatabaseConnectionType::Mysql,
+        host: 'db.staging.io',
+        port: 3306,
+        database: 'stagingdb',
+        schema: null,
+        username: 'root',
+        password: 'secret',
+        isProduction: false,
+    );
+}
 
 function makeBuilderCloningConfig(): CloningConfigData
 {
@@ -71,6 +103,8 @@ it('builds an AuditRecordData from config and result', function (): void {
         startedAt: $startedAt,
         finishedAt: $finishedAt,
         yamlFileName: 'test.cloning.yaml',
+        sourceConnectionData: makeBuilderSourceConnection(),
+        targetConnectionData: makeBuilderTargetConnection(),
     );
 
     expect($record)->toBeInstanceOf(AuditRecordData::class);
@@ -81,4 +115,40 @@ it('builds an AuditRecordData from config and result', function (): void {
     expect($record->tables)->toHaveCount(1);
     expect($record->contentHash)->not->toBeEmpty();
     expect($record->hmacSignature)->not->toBeEmpty();
+    expect($record->sourceConnectionDetails)->toMatchArray([
+        'name' => 'production-db',
+        'type' => 'mysql',
+        'host' => 'db.prod.io',
+        'port' => 3306,
+        'database' => 'mydb',
+        'username' => 'root',
+    ]);
+    expect($record->targetConnectionDetails)->toMatchArray([
+        'name' => 'staging',
+        'type' => 'mysql',
+        'host' => 'db.staging.io',
+        'port' => 3306,
+        'database' => 'stagingdb',
+        'username' => 'root',
+    ]);
+    expect(json_encode($record->sourceConnectionDetails))->not->toContain('secret');
+    expect(json_encode($record->targetConnectionDetails))->not->toContain('secret');
+});
+
+it('builds a record without ConnectionData (legacy callers) producing stub details', function (): void {
+    $signer = new AuditLogSigner;
+    $builder = new AuditLogBuilder($signer);
+
+    $record = $builder->build(
+        config: makeBuilderCloningConfig(),
+        result: makeBuilderRunResult(),
+        targetConnection: 'staging',
+        startedAt: new DateTimeImmutable('2026-04-01T14:32:00', new DateTimeZone('UTC')),
+        finishedAt: new DateTimeImmutable('2026-04-01T14:34:14', new DateTimeZone('UTC')),
+        yamlFileName: 'test.cloning.yaml',
+    );
+
+    expect($record->sourceConnectionDetails['name'])->toBe('production-db');
+    expect($record->sourceConnectionDetails['host'])->toBeNull();
+    expect($record->targetConnectionDetails['name'])->toBe('staging');
 });

--- a/tests/Unit/Services/Audit/AuditLogRendererTest.php
+++ b/tests/Unit/Services/Audit/AuditLogRendererTest.php
@@ -49,6 +49,8 @@ function makeFullAuditRecord(): AuditRecordData
         channels: [],
         contentHash: 'abc123',
         hmacSignature: 'sig456',
+        sourceConnectionDetails: ['name' => 'production-db', 'type' => 'mysql', 'host' => 'db.prod.io', 'port' => 3306, 'database' => 'mydb', 'schema' => null, 'username' => 'root'],
+        targetConnectionDetails: ['name' => 'staging', 'type' => 'mysql', 'host' => 'db.staging.io', 'port' => 3306, 'database' => 'stagingdb', 'schema' => null, 'username' => 'root'],
     );
 }
 
@@ -112,4 +114,37 @@ it('renders a PDF document', function (): void {
 
     expect($pdf)->toStartWith('%PDF-')
         ->and(strlen($pdf))->toBeGreaterThan(1000);
+});
+
+it('renders the Summary & Integrity section with connection details', function (): void {
+    $renderer = new AuditLogRenderer;
+    $record = makeFullAuditRecord();
+
+    $signer = new AuditLogSigner;
+    [$canonicalJson] = $signer->sign($record);
+
+    $html = $renderer->render($record, $canonicalJson);
+
+    expect($html)->toContain('Summary &amp; Integrity');
+    expect($html)->toContain('class="conn-grid"');
+    expect($html)->toContain('class="conn-eyebrow">Source<');
+    expect($html)->toContain('class="conn-eyebrow">Target<');
+    expect($html)->toContain('db.prod.io:3306');
+    expect($html)->toContain('db.staging.io:3306');
+    expect($html)->toContain('mydb');
+    expect($html)->toContain('stagingdb');
+    expect($html)->toContain('class="kpi kpi-3"');
+    expect($html)->not->toContain('secret'); // password must never leak
+});
+
+it('forces a page break before the PII transformations heading', function (): void {
+    $renderer = new AuditLogRenderer;
+    $record = makeFullAuditRecord();
+
+    $signer = new AuditLogSigner;
+    [$canonicalJson] = $signer->sign($record);
+
+    $html = $renderer->render($record, $canonicalJson);
+
+    expect($html)->toContain('<h2 class="page-break">PII transformations');
 });

--- a/tests/Unit/Services/Audit/AuditLogSignerTest.php
+++ b/tests/Unit/Services/Audit/AuditLogSignerTest.php
@@ -30,6 +30,8 @@ function makeAuditRecord(): AuditRecordData
         channels: [],
         contentHash: '',
         hmacSignature: '',
+        sourceConnectionDetails: ['name' => 'production-db', 'type' => 'mysql', 'host' => 'db.prod.io', 'port' => 3306, 'database' => 'mydb', 'schema' => null, 'username' => 'root'],
+        targetConnectionDetails: ['name' => 'staging', 'type' => 'mysql', 'host' => 'db.staging.io', 'port' => 3306, 'database' => 'stagingdb', 'schema' => null, 'username' => 'root'],
     );
 }
 


### PR DESCRIPTION
## Summary

The closing audit page now duplicates the run summary so a reader landing on the last page can confirm *what happened* without flipping back to the cover. The Integrity section is renamed **Summary & Integrity** and now contains:

- **Source and target connection cards** — name, type, host:port, database, optional schema, username. Passwords are never rendered or stored in the audit record.
- **3-up KPI strip** — rows transferred (with table count), PII columns anonymised, total duration.
- **Integrity card** (dark, unchanged) — SHA-256 + HMAC signature.

The **PII transformations** heading also receives `class="page-break"` so its table is no longer split across the cover page.

## Data model changes

`AuditRecordData` gains two new fields embedded in the canonical JSON (and therefore covered by the existing HMAC signature):

```php
public array $sourceConnectionDetails; // {name, type, host, port, database, schema, username}
public array $targetConnectionDetails; // same shape
```

`AuditLogBuilder::build()` now accepts optional `ConnectionData` objects for source and target and projects them into password-free arrays. `RunCommand` passes the connections it already resolved in Phase 2.

> **Note on signatures:** existing audit logs signed *before* this change still verify against their original `.sig` files because they don't reference the new fields. New runs will produce a different canonical JSON shape (and therefore a different hash) — `cloning:verify-audit` continues to work because it always reconstructs the canonical JSON from the embedded payload.

## Docs

- `specs/PRD-audit-delivery.md` — updated DTO reference and §4.5 *Summary & Integrity Section*.
- Tolaria knowledge base note `clonio-audit.md` — refreshed artefact layout description.

Closes #105.

## Test plan

- [x] `composer test` — 506 tests / 1498 assertions, type coverage 99.3%, PHPStan max clean, Pint + Rector clean
- [x] New renderer tests assert the section, connection details, and `kpi-3` markup are emitted; an explicit assertion confirms the password literal never leaks into the rendered HTML
- [x] Builder tests cover both the new ConnectionData path (full details) and the legacy null-ConnectionData path (stub details with the connection name only)
- [x] HTML + PDF preview rendered locally with realistic data and visually verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)