### PR TITLE
feat(cloning): add template anonymization strategy with {fakerMethod} placeholders

### DIFF
--- a/app/Commands/Cloning/ColumnEditCommand.php
+++ b/app/Commands/Cloning/ColumnEditCommand.php
@@ -28,7 +28,7 @@ class ColumnEditCommand extends Command
         {file?              : Path to the .cloning.yaml file}
         {--table=           : Table name}
         {--column=          : Column name}
-        {--strategy=        : Strategy to apply (keep, fake, hash, mask, static, remapping)}
+        {--strategy=        : Strategy to apply (keep, fake, hash, mask, static, template, remapping)}
         {--faker-method=    : (fake) Faker method name}
         {--faker-arguments= : (fake) Comma-separated faker arguments}
         {--algorithm=       : (hash) Hash algorithm}
@@ -37,6 +37,7 @@ class ColumnEditCommand extends Command
         {--visible-chars=   : (mask) Number of visible characters}
         {--preserve-format  : (mask) Preserve original format}
         {--value=           : (static) Static replacement value}
+        {--template=        : (template) Template with {fakerMethod} placeholders}
         {--remapping-use=   : (remapping) random_integer | new_uuid}';
 
     /**
@@ -87,6 +88,13 @@ class ColumnEditCommand extends Command
                 'description' => 'Replace every value with a fixed string.',
                 'parameters' => [
                     ['name' => 'value', 'label' => 'Static value', 'type' => 'string', 'default' => ''],
+                ],
+            ],
+            'template' => [
+                'label' => 'Template',
+                'description' => 'Build a string by mixing literal text with {fakerMethod} placeholders. Example: {userName}@acme.test',
+                'parameters' => [
+                    ['name' => 'template', 'label' => 'Template (use {fakerMethod} for placeholders)', 'type' => 'string', 'default' => ''],
                 ],
             ],
             'remapping' => [

--- a/app/Commands/Cloning/DumpCommand.php
+++ b/app/Commands/Cloning/DumpCommand.php
@@ -180,6 +180,7 @@ class DumpCommand extends Command
                         staticValue: $transformation->staticValue,
                         piiDetected: true,
                         piiCategory: $matcher->name,
+                        template: $transformation->template,
                     );
                 } else {
                     $columnDump = new ColumnDumpData(

--- a/app/Commands/Matchers/CheckCommand.php
+++ b/app/Commands/Matchers/CheckCommand.php
@@ -120,6 +120,8 @@ class CheckCommand extends Command
             $this->line(sprintf('      preserve_format: %s', ($t->preserveFormat ?? false) ? 'true' : 'false'));
         } elseif ($t->strategy === 'static') {
             $this->line(sprintf('      value:          "%s"', $t->staticValue ?? ''));
+        } elseif ($t->strategy === 'template') {
+            $this->line(sprintf('      template:       "%s"', $t->template ?? ''));
         }
 
         $this->line('');

--- a/app/Commands/Matchers/ListCommand.php
+++ b/app/Commands/Matchers/ListCommand.php
@@ -97,6 +97,8 @@ class ListCommand extends Command
                         $transformLabel = sprintf('hash → %s', $matcher->transformation->hashAlgorithm ?? 'sha256');
                     } elseif ($matcher->transformation->strategy === 'mask') {
                         $transformLabel = 'mask';
+                    } elseif ($matcher->transformation->strategy === 'template' && $matcher->transformation->template !== null) {
+                        $transformLabel = sprintf('template → %s', $matcher->transformation->template);
                     } else {
                         $transformLabel = $matcher->transformation->strategy;
                     }

--- a/app/Data/Cloning/ColumnCloningConfigData.php
+++ b/app/Data/Cloning/ColumnCloningConfigData.php
@@ -21,6 +21,7 @@ final readonly class ColumnCloningConfigData
         public ?int $visibleChars,
         public ?bool $preserveFormat,
         public ?string $staticValue,
+        public ?string $template = null,
         public ?string $remappingUse = null,
         public ?array $remappingForeignKeys = null,
     ) {}

--- a/app/Data/Cloning/ColumnDumpData.php
+++ b/app/Data/Cloning/ColumnDumpData.php
@@ -20,5 +20,6 @@ final readonly class ColumnDumpData
         public ?string $staticValue,
         public bool $piiDetected,
         public ?string $piiCategory,
+        public ?string $template = null,
     ) {}
 }

--- a/app/Services/Cloning/AnonymizationEngine.php
+++ b/app/Services/Cloning/AnonymizationEngine.php
@@ -30,6 +30,7 @@ class AnonymizationEngine
             'fake' => $this->applyFake($config),
             'hash' => $this->applyHash(is_scalar($value) ? (string) $value : '', $config),
             'mask' => $this->applyMask(is_scalar($value) ? (string) $value : '', $config),
+            'template' => $this->applyTemplate($config),
             default => $value,
         };
     }
@@ -55,6 +56,46 @@ class AnonymizationEngine
     private function applyHash(string $value, ColumnCloningConfigData $config): string
     {
         return hash($config->hashAlgorithm ?? 'sha256', ($config->hashSalt ?? '').$value);
+    }
+
+    /**
+     * Expand a template string by replacing `{fakerMethod}` placeholders with
+     * Faker output. Literal text passes through unchanged. Useful for mixing
+     * randomized parts with fixed parts (e.g. fixed email domain).
+     *
+     * Example: `{userName}@acme.test` → `alice.j42@acme.test`
+     *
+     * Unknown methods on the Faker generator render as the empty string so
+     * pipelines fail soft; the validator rejects them at config-load time.
+     */
+    private function applyTemplate(ColumnCloningConfigData $config): string
+    {
+        $template = $config->template;
+
+        if ($template === null || $template === '') {
+            return '';
+        }
+
+        return (string) preg_replace_callback(
+            '/\{([a-zA-Z][a-zA-Z0-9]*)\}/',
+            function (array $matches): string {
+                $method = $matches[1];
+
+                if (! method_exists($this->faker, $method)) {
+                    return '';
+                }
+
+                /** @var mixed $result */
+                $result = $this->faker->{$method}();
+
+                if (is_array($result)) {
+                    return implode(' ', array_map(static fn (mixed $v): string => is_scalar($v) ? (string) $v : '', $result));
+                }
+
+                return is_scalar($result) ? (string) $result : '';
+            },
+            $template,
+        );
     }
 
     private function applyMask(string $value, ColumnCloningConfigData $config): string

--- a/app/Services/Cloning/CloningYamlLoader.php
+++ b/app/Services/Cloning/CloningYamlLoader.php
@@ -260,6 +260,7 @@ class CloningYamlLoader
         $visibleChars = null;
         $preserveFormat = null;
         $staticValue = null;
+        $template = null;
         $remappingUse = null;
         $remappingForeignKeys = null;
 
@@ -286,6 +287,11 @@ class CloningYamlLoader
             case 'static':
                 $rawValue = $config['value'] ?? null;
                 $staticValue = is_scalar($rawValue) ? (string) $rawValue : null;
+                break;
+
+            case 'template':
+                $rawTemplate = $config['template'] ?? null;
+                $template = is_string($rawTemplate) ? $rawTemplate : null;
                 break;
 
             case 'remapping':
@@ -342,6 +348,7 @@ class CloningYamlLoader
             visibleChars: $visibleChars,
             preserveFormat: $preserveFormat,
             staticValue: $staticValue,
+            template: $template,
             remappingUse: $remappingUse,
             remappingForeignKeys: $remappingForeignKeys,
         );

--- a/app/Services/Cloning/CloningYamlValidator.php
+++ b/app/Services/Cloning/CloningYamlValidator.php
@@ -26,7 +26,7 @@ class CloningYamlValidator
 
     private const array VALID_ROW_STRATEGIES = ['full', 'first', 'last', 'skip'];
 
-    private const array VALID_COLUMN_STRATEGIES = ['keep', 'fake', 'hash', 'mask', 'null', 'static', 'remapping'];
+    private const array VALID_COLUMN_STRATEGIES = ['keep', 'fake', 'hash', 'mask', 'null', 'static', 'template', 'remapping'];
 
     private const array VALID_HASH_ALGORITHMS = ['sha256', 'sha512', 'md5', 'sha1'];
 
@@ -411,6 +411,24 @@ class CloningYamlValidator
             case 'static':
                 if (! array_key_exists('value', $config)) {
                     $errors[] = sprintf("%s: 'static' strategy requires 'value'", $prefix);
+                }
+
+                break;
+
+            case 'template':
+                $template = $config['template'] ?? null;
+
+                if (! is_string($template) || $template === '') {
+                    $errors[] = sprintf("%s: 'template' strategy requires non-empty 'template' string", $prefix);
+                    break;
+                }
+
+                if (preg_match_all('/\{([a-zA-Z][a-zA-Z0-9]*)\}/', $template, $matches) > 0) {
+                    foreach ($matches[1] as $method) {
+                        if (! in_array($method, self::KNOWN_FAKER_METHODS, true)) {
+                            $errors[] = sprintf("%s: template references unknown faker method '%s'", $prefix, $method);
+                        }
+                    }
                 }
 
                 break;

--- a/app/Services/Cloning/CloningYamlWriter.php
+++ b/app/Services/Cloning/CloningYamlWriter.php
@@ -120,6 +120,10 @@ class CloningYamlWriter
                             $lines[] = sprintf('        value: %s', $this->encodeYamlScalar($column->staticValue));
                             break;
 
+                        case 'template':
+                            $lines[] = sprintf('        template: %s', $this->encodeYamlScalar($column->template));
+                            break;
+
                         case 'keep':
                             // no extra fields needed
                             break;

--- a/app/Services/Pii/PiiMatcherYamlReader.php
+++ b/app/Services/Pii/PiiMatcherYamlReader.php
@@ -174,6 +174,10 @@ class PiiMatcherYamlReader
             ? $rawTransformation['value']
             : null;
 
+        $template = isset($rawTransformation['template']) && is_string($rawTransformation['template'])
+            ? $rawTransformation['template']
+            : null;
+
         /** @var list<scalar> $fakerArguments */
         return new ColumnCloningConfigData(
             columnName: $columnName,
@@ -186,6 +190,7 @@ class PiiMatcherYamlReader
             visibleChars: $visibleChars,
             preserveFormat: $preserveFormat,
             staticValue: $staticValue,
+            template: $template,
         );
     }
 }

--- a/app/Services/Pii/PiiMatcherYamlWriter.php
+++ b/app/Services/Pii/PiiMatcherYamlWriter.php
@@ -63,6 +63,8 @@ class PiiMatcherYamlWriter
                     }
                 } elseif ($t->strategy === 'static') {
                     $transformationData['value'] = $t->staticValue ?? '';
+                } elseif ($t->strategy === 'template') {
+                    $transformationData['template'] = $t->template ?? '';
                 }
 
                 $matcherEntry['transformation'] = $transformationData;

--- a/docs/cloning-yaml.md
+++ b/docs/cloning-yaml.md
@@ -259,6 +259,36 @@ environment_tag:
 
 ---
 
+### `template`
+
+Build a string by mixing literal text with `{fakerMethod}` placeholders. Each placeholder is expanded to the output of the named [Faker method](#supported-faker-methods) (no-argument form). Useful when only part of a value needs to be randomized — typically a fixed email domain, a fixed phone prefix, or a fixed organizational suffix.
+
+```yaml
+email:
+  strategy: template
+  template: "{userName}@acme.test"
+
+display_name:
+  strategy: template
+  template: "{firstName} {lastName}"
+
+support_ref:
+  strategy: template
+  template: "ACME-{uuid}"
+```
+
+| Field | Required | Description |
+|-------|:--------:|-------------|
+| `template` | yes | Non-empty string. Tokens of the form `{methodName}` are replaced; everything else is passed through. The validator rejects unknown faker methods at config-load time. |
+
+Notes:
+
+- Only no-argument Faker methods are supported inside `{…}`. For arguments, use the regular `fake` strategy.
+- The original column value is **not** read. Each output is freshly generated per row, so cross-run linkability is defeated by design.
+- Validators reject `{unknown}` tokens; at runtime, unknown methods render as the empty string (defense in depth).
+
+---
+
 ### `remapping`
 
 Assign a new primary key value to each transferred row and rewrite all foreign key columns that reference it, preventing ID collisions on the target.

--- a/specs/PRD-cloning-yaml-schema.md
+++ b/specs/PRD-cloning-yaml-schema.md
@@ -78,7 +78,7 @@ tables:
       clear: false       # optional; false | truncate | delete — default false
     columns:             # optional section; see column rule below
       <column_name>:
-        strategy: keep   # keep | fake | hash | mask | null | static
+        strategy: keep   # keep | fake | hash | mask | null | static | template
         # strategy-specific options follow (see §5)
 ```
 
@@ -184,6 +184,24 @@ environment_tag:
 | Field | Type | Required | Description |
 |-------|------|:--------:|-------------|
 | `value` | string | yes | The fixed value to use (may be empty string) |
+
+### 5.7 `template`
+
+Build a string from literal text mixed with `{fakerMethod}` placeholders. Each placeholder is replaced with the no-argument output of the named Faker method. The original column value is **not** read — every output is freshly generated.
+
+```yaml
+email:
+  strategy: template
+  template: "{userName}@acme.test"
+```
+
+| Field | Type | Required | Description |
+|-------|------|:--------:|-------------|
+| `template` | string | yes | Non-empty template. Tokens `{methodName}` are expanded; other text passes through. Methods must be in §6. |
+
+Constraints:
+- Only no-argument Faker methods are accepted inside `{…}`. For methods with arguments (e.g. `numerify`), use the `fake` strategy instead.
+- The validator rejects unknown method names at config-load time.
 
 ---
 
@@ -440,7 +458,7 @@ A YAML language server hint can be placed at the top of every generated file:
       "properties": {
         "strategy": {
           "type": "string",
-          "enum": ["keep", "fake", "hash", "mask", "null", "static"]
+          "enum": ["keep", "fake", "hash", "mask", "null", "static", "template"]
         },
         "faker_method": {
           "type": "string",
@@ -481,6 +499,11 @@ A YAML language server hint can be placed at the top of every generated file:
         "value": {
           "type": "string",
           "description": "Fixed replacement value. Required when strategy is 'static'."
+        },
+        "template": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Template string with {fakerMethod} placeholders. Required when strategy is 'template'."
         }
       },
       "allOf": [
@@ -499,6 +522,10 @@ A YAML language server hint can be placed at the top of every generated file:
         {
           "if": { "properties": { "strategy": { "const": "static" } }, "required": ["strategy"] },
           "then": { "required": ["value"] }
+        },
+        {
+          "if": { "properties": { "strategy": { "const": "template" } }, "required": ["strategy"] },
+          "then": { "required": ["template"] }
         }
       ]
     }
@@ -534,9 +561,9 @@ tables:
       # Only columns that need transformation are listed.
       # All other columns (id, status, created_at, …) are implicitly kept as-is.
       email:
-        strategy: fake
-        faker_method: safeEmail
-        faker_arguments: []
+        # Template: fixed domain, randomized local part.
+        strategy: template
+        template: "{userName}@acme.test"
       first_name:
         strategy: fake
         faker_method: firstName

--- a/specs/PRD-pii-matchers.md
+++ b/specs/PRD-pii-matchers.md
@@ -178,6 +178,22 @@ transformation:
   value: "[REDACTED]"
 ```
 
+### 7.6 `strategy: template`
+
+Build a string from literal text plus `{fakerMethod}` placeholders. Each placeholder is replaced with the no-argument output of the named Faker method. Useful when only part of a value needs to be randomized (e.g. fixed email domain).
+
+```yaml
+transformation:
+  strategy: template
+  template: "{userName}@acme.test"
+```
+
+| Field | Required | Description |
+|-------|:--------:|-------------|
+| `template` | yes | Non-empty template string. Unknown method names are rejected at config-load time. |
+
+Only no-argument Faker methods may appear inside `{…}`. For arguments, use `strategy: fake` instead.
+
 ---
 
 ## 8. Baseline Groups and Matchers

--- a/tests/Unit/Services/Cloning/AnonymizationEngineTest.php
+++ b/tests/Unit/Services/Cloning/AnonymizationEngineTest.php
@@ -14,6 +14,7 @@ function makeColumn(
     ?string $maskChar = null,
     ?int $visibleChars = null,
     ?bool $preserveFormat = null,
+    ?string $template = null,
 ): ColumnCloningConfigData {
     return new ColumnCloningConfigData(
         columnName: 'test_col',
@@ -26,6 +27,7 @@ function makeColumn(
         visibleChars: $visibleChars,
         preserveFormat: $preserveFormat,
         staticValue: $staticValue,
+        template: $template,
     );
 }
 
@@ -94,4 +96,51 @@ it('does not mask when value is shorter than visible chars', function (): void {
     $engine = new AnonymizationEngine;
     $col = makeColumn('mask', maskChar: '*', visibleChars: 100, preserveFormat: false);
     expect($engine->transform('hi', $col))->toBe('hi');
+});
+
+it('expands template placeholders with faker output', function (): void {
+    $engine = new AnonymizationEngine;
+    $col = makeColumn('template', template: '{userName}@acme.test');
+    $result = $engine->transform('alice@somewhere.com', $col);
+
+    expect($result)->toBeString();
+    expect($result)->toEndWith('@acme.test');
+    expect($result)->not->toBe('{userName}@acme.test');
+});
+
+it('keeps literal text outside placeholders', function (): void {
+    $engine = new AnonymizationEngine;
+    $col = makeColumn('template', template: 'static-prefix-{uuid}-suffix');
+    $result = $engine->transform('input', $col);
+
+    expect($result)->toBeString();
+    expect($result)->toStartWith('static-prefix-');
+    expect($result)->toEndWith('-suffix');
+});
+
+it('renders unknown faker method as empty string in template', function (): void {
+    $engine = new AnonymizationEngine;
+    $col = makeColumn('template', template: 'before-{thisMethodDoesNotExist}-after');
+    $result = $engine->transform('input', $col);
+
+    expect($result)->toBe('before--after');
+});
+
+it('returns empty string when template is null or empty', function (): void {
+    $engine = new AnonymizationEngine;
+    $col = makeColumn('template', template: null);
+    expect($engine->transform('input', $col))->toBe('');
+
+    $col = makeColumn('template', template: '');
+    expect($engine->transform('input', $col))->toBe('');
+});
+
+it('expands multiple placeholders in one template', function (): void {
+    $engine = new AnonymizationEngine;
+    $col = makeColumn('template', template: '{firstName}.{lastName}@firma.de');
+    $result = $engine->transform('input', $col);
+
+    expect($result)->toBeString();
+    expect($result)->toEndWith('@firma.de');
+    expect($result)->toContain('.');
 });

--- a/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
@@ -269,6 +269,47 @@ it('passes a valid static column', function (): void {
     expect($errors)->toBe([]);
 });
 
+it('passes a valid template column', function (): void {
+    $validator = new CloningYamlValidator;
+    $config = makeValidConfig();
+    $config['tables']['users']['columns']['email'] = [
+        'strategy' => 'template',
+        'template' => '{userName}@acme.test',
+    ];
+
+    $errors = $validator->validate($config);
+
+    expect($errors)->toBe([]);
+});
+
+it('returns error when template strategy has empty template', function (): void {
+    $validator = new CloningYamlValidator;
+    $config = makeValidConfig();
+    $config['tables']['users']['columns']['email'] = [
+        'strategy' => 'template',
+        'template' => '',
+    ];
+
+    $errors = $validator->validate($config);
+
+    expect($errors)->not->toBe([]);
+    expect(implode(' ', $errors))->toContain('template');
+});
+
+it('returns error when template references unknown faker method', function (): void {
+    $validator = new CloningYamlValidator;
+    $config = makeValidConfig();
+    $config['tables']['users']['columns']['email'] = [
+        'strategy' => 'template',
+        'template' => '{notAFakerMethod}@acme.test',
+    ];
+
+    $errors = $validator->validate($config);
+
+    expect($errors)->not->toBe([]);
+    expect(implode(' ', $errors))->toContain('notAFakerMethod');
+});
+
 // ─── key_remapping validation ─────────────────────────────────────────────────
 
 it('passes validation for a valid key_remapping section with new_uuid strategy', function (): void {


### PR DESCRIPTION
## Summary
- Add a new \`template\` column strategy that expands \`{fakerMethod}\` placeholders against FakerPHP — e.g. \`{userName}@acme.test\` or \`+49 {numerify}\`.
- Validator rejects empty templates and unknown faker method names at config-load time; engine renders unknown placeholders as empty strings as a runtime fallback.
- Wire the new strategy through \`ColumnCloningConfigData\`, the cloning YAML loader/writer, the PII matcher reader/writer, the \`column:edit\` command, and \`matchers:check\` / \`matchers:list\` display.
- Document the strategy in \`docs/cloning-yaml.md\`, \`specs/PRD-cloning-yaml-schema.md\`, and \`specs/PRD-pii-matchers.md\` with examples.

## Test plan
- [ ] \`composer test\` green
- [ ] \`clonio cloning:column-edit --strategy=template --template='{userName}@acme.test'\` round-trips through YAML
- [ ] A cloning run with a templated email column produces values like \`john_doe@acme.test\` (real user-shaped local part, fixed domain)
- [ ] Validator errors on \`template: ''\` and on unknown placeholders like \`{notARealMethod}\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)