### PR TITLE
refactor(audit): S3 delivery via Flysystem instead of hand-rolled SigV4 cURL

### DIFF
--- a/app/Services/Audit/S3DeliveryAdapter.php
+++ b/app/Services/Audit/S3DeliveryAdapter.php
@@ -6,7 +6,7 @@ namespace App\Services\Audit;
 
 use App\Contracts\DeliveryAdapterInterface;
 use Illuminate\Support\Facades\Crypt;
-use RuntimeException;
+use Illuminate\Support\Facades\Storage;
 
 class S3DeliveryAdapter implements DeliveryAdapterInterface
 {
@@ -19,9 +19,20 @@ class S3DeliveryAdapter implements DeliveryAdapterInterface
         $secretKey = $this->decryptIfNeeded(is_string($channelConfig['secret_key'] ?? null) ? $channelConfig['secret_key'] : '');
         $pathPrefix = is_string($channelConfig['path_prefix'] ?? null) ? $channelConfig['path_prefix'] : '';
 
+        $disk = Storage::build([
+            'driver' => 's3',
+            'key' => $accessKey,
+            'secret' => $secretKey,
+            'region' => $region,
+            'bucket' => $bucket,
+            'endpoint' => $endpoint !== '' ? $endpoint : null,
+            'use_path_style_endpoint' => $endpoint !== '',
+            'throw' => true,
+        ]);
+
         foreach ($artefacts as $filename => $content) {
             $key = $this->resolveKey($pathPrefix, $filename, $templateVars);
-            $this->putObject($endpoint, $bucket, $key, $content, $region, $accessKey, $secretKey);
+            $disk->put($key, $content);
         }
     }
 
@@ -37,74 +48,6 @@ class S3DeliveryAdapter implements DeliveryAdapterInterface
         $resolved = rtrim($resolved, '/');
 
         return $resolved !== '' ? $resolved.'/'.$filename : $filename;
-    }
-
-    private function putObject(string $endpoint, string $bucket, string $key, string $content, string $region, string $accessKey, string $secretKey): void
-    {
-        $parsedHost = parse_url($endpoint, PHP_URL_HOST);
-        $host = is_string($parsedHost) ? $parsedHost : '';
-        $url = rtrim($endpoint, '/').'/'.$bucket.'/'.ltrim($key, '/');
-        $date = gmdate('Ymd\THis\Z');
-        $dateShort = gmdate('Ymd');
-        $contentHash = hash('sha256', $content);
-
-        $canonicalUri = '/'.$bucket.'/'.ltrim($key, '/');
-        $headers = [
-            'host' => $host,
-            'x-amz-content-sha256' => $contentHash,
-            'x-amz-date' => $date,
-        ];
-
-        ksort($headers);
-        $signedHeaders = implode(';', array_keys($headers));
-        $canonicalHeaders = '';
-
-        foreach ($headers as $k => $v) {
-            $canonicalHeaders .= $k.':'.$v."\n";
-        }
-
-        $canonicalRequest = implode("\n", ['PUT', $canonicalUri, '', $canonicalHeaders, $signedHeaders, $contentHash]);
-        $scope = $dateShort.'/'.$region.'/s3/aws4_request';
-        $stringToSign = implode("\n", ['AWS4-HMAC-SHA256', $date, $scope, hash('sha256', $canonicalRequest)]);
-
-        $signingKey = hash_hmac('sha256', 'aws4_request',
-            hash_hmac('sha256', 's3',
-                hash_hmac('sha256', $region,
-                    hash_hmac('sha256', $dateShort, 'AWS4'.$secretKey, true),
-                    true),
-                true),
-            true);
-
-        $signature = hash_hmac('sha256', $stringToSign, $signingKey);
-        $authorization = sprintf(
-            'AWS4-HMAC-SHA256 Credential=%s/%s, SignedHeaders=%s, Signature=%s',
-            $accessKey, $scope, $signedHeaders, $signature
-        );
-
-        $ch = curl_init($url);
-
-        throw_if($ch === false, RuntimeException::class, 'Failed to initialize cURL for S3 upload');
-
-        curl_setopt_array($ch, [
-            CURLOPT_CUSTOMREQUEST => 'PUT',
-            CURLOPT_POSTFIELDS => $content,
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_HTTPHEADER => [
-                'Authorization: '.$authorization,
-                'x-amz-content-sha256: '.$contentHash,
-                'x-amz-date: '.$date,
-                'Content-Length: '.strlen($content),
-            ],
-            CURLOPT_TIMEOUT => 30,
-        ]);
-
-        $response = curl_exec($ch);
-        $httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
-        $error = curl_error($ch);
-
-        if ($httpCode < 200 || $httpCode >= 300) {
-            throw new RuntimeException(sprintf('S3 PUT failed (HTTP %d): %s', $httpCode, is_string($response) ? $response : $error));
-        }
     }
 
     private function decryptIfNeeded(string $value): string

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "illuminate/http": "^12.60.2",
         "illuminate/log": "^12.60.2",
         "laravel-zero/framework": "^12.1.0",
+        "league/flysystem-aws-s3-v3": "^3.0",
         "mpdf/mpdf": "^8.3.1",
         "symfony/yaml": "^8.0.12"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,159 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1ffcc0bd4ac90519bdc8232f276b42c",
+    "content-hash": "5fb3621b28fc3ad63ede3bbe76ba391b",
     "packages": [
+        {
+            "name": "aws/aws-crt-php",
+            "version": "v1.2.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/awslabs/aws-crt-php.git",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/awslabs/aws-crt-php/zipball/d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "reference": "d71d9906c7bb63a28295447ba12e74723bd3730e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35||^5.6.3||^9.5",
+                "yoast/phpunit-polyfills": "^1.0"
+            },
+            "suggest": {
+                "ext-awscrt": "Make sure you install awscrt native extension to use any of the functionality."
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "AWS SDK Common Runtime Team",
+                    "email": "aws-sdk-common-runtime@amazon.com"
+                }
+            ],
+            "description": "AWS Common Runtime for PHP",
+            "homepage": "https://github.com/awslabs/aws-crt-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "crt",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/awslabs/aws-crt-php/issues",
+                "source": "https://github.com/awslabs/aws-crt-php/tree/v1.2.7"
+            },
+            "time": "2024-10-18T22:15:13+00:00"
+        },
+        {
+            "name": "aws/aws-sdk-php",
+            "version": "3.381.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/aws/aws-sdk-php.git",
+                "reference": "9be3422631494111ec76bec677f1ae2dec650573"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/9be3422631494111ec76bec677f1ae2dec650573",
+                "reference": "9be3422631494111ec76bec677f1ae2dec650573",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-crt-php": "^1.2.3",
+                "ext-json": "*",
+                "ext-pcre": "*",
+                "ext-simplexml": "*",
+                "guzzlehttp/guzzle": "^7.4.5",
+                "guzzlehttp/promises": "^2.0",
+                "guzzlehttp/psr7": "^2.4.5",
+                "mtdowling/jmespath.php": "^2.8.0",
+                "php": ">=8.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "symfony/filesystem": "^v5.4.45 || ^v6.4.3 || ^v7.1.0 || ^v8.0.0"
+            },
+            "require-dev": {
+                "andrewsville/php-token-reflection": "^1.4",
+                "aws/aws-php-sns-message-validator": "~1.0",
+                "behat/behat": "~3.0",
+                "composer/composer": "^2.7.8",
+                "dms/phpunit-arraysubset-asserts": "^v0.5.0",
+                "doctrine/cache": "~1.4",
+                "ext-dom": "*",
+                "ext-openssl": "*",
+                "ext-sockets": "*",
+                "phpunit/phpunit": "^10.0",
+                "psr/cache": "^2.0 || ^3.0",
+                "psr/simple-cache": "^2.0 || ^3.0",
+                "sebastian/comparator": "^1.2.3 || ^4.0 || ^5.0",
+                "yoast/phpunit-polyfills": "^2.0"
+            },
+            "suggest": {
+                "aws/aws-php-sns-message-validator": "To validate incoming SNS notifications",
+                "doctrine/cache": "To use the DoctrineCacheAdapter",
+                "ext-curl": "To send requests using cURL",
+                "ext-openssl": "Allows working with CloudFront private distributions and verifying received SNS messages",
+                "ext-pcntl": "To use client-side monitoring",
+                "ext-sockets": "To use client-side monitoring"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "Aws\\": "src/"
+                },
+                "exclude-from-classmap": [
+                    "src/data/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Amazon Web Services",
+                    "homepage": "https://aws.amazon.com"
+                }
+            ],
+            "description": "AWS SDK for PHP - Use Amazon Web Services in your PHP project",
+            "homepage": "https://aws.amazon.com/sdk-for-php",
+            "keywords": [
+                "amazon",
+                "aws",
+                "cloud",
+                "dynamodb",
+                "ec2",
+                "glacier",
+                "s3",
+                "sdk"
+            ],
+            "support": {
+                "forum": "https://github.com/aws/aws-sdk-php/discussions",
+                "issues": "https://github.com/aws/aws-sdk-php/issues",
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.381.6"
+            },
+            "time": "2026-05-21T20:14:47+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.14.8",
@@ -2722,6 +2873,61 @@
             "time": "2026-05-14T10:28:08+00:00"
         },
         {
+            "name": "league/flysystem-aws-s3-v3",
+            "version": "3.34.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "reference": "0c62fdac907791d8649ad3c61cb7a77628344fb8",
+                "shasum": ""
+            },
+            "require": {
+                "aws/aws-sdk-php": "^3.371.5",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\AwsS3V3\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "AWS S3 filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "aws",
+                "file",
+                "files",
+                "filesystem",
+                "s3",
+                "storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.34.0"
+            },
+            "time": "2026-05-04T08:24:00+00:00"
+        },
+        {
             "name": "league/flysystem-local",
             "version": "3.31.0",
             "source": {
@@ -3102,6 +3308,72 @@
                 "source": "https://github.com/mpdf/psr-log-aware-trait/tree/v3.0.0"
             },
             "time": "2023-05-03T06:19:36+00:00"
+        },
+        {
+            "name": "mtdowling/jmespath.php",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jmespath/jmespath.php.git",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jmespath/jmespath.php/zipball/a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "reference": "a2a865e05d5f420b50cc2f85bb78d565db12a6bc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2.5 || ^8.0",
+                "symfony/polyfill-mbstring": "^1.17"
+            },
+            "require-dev": {
+                "composer/xdebug-handler": "^3.0.3",
+                "phpunit/phpunit": "^8.5.33"
+            },
+            "bin": [
+                "bin/jp.php"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/JmesPath.php"
+                ],
+                "psr-4": {
+                    "JmesPath\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Graham Campbell",
+                    "email": "hello@gjcampbell.co.uk",
+                    "homepage": "https://github.com/GrahamCampbell"
+                },
+                {
+                    "name": "Michael Dowling",
+                    "email": "mtdowling@gmail.com",
+                    "homepage": "https://github.com/mtdowling"
+                }
+            ],
+            "description": "Declaratively specify how to extract elements from a JSON document",
+            "keywords": [
+                "json",
+                "jsonpath"
+            ],
+            "support": {
+                "issues": "https://github.com/jmespath/jmespath.php/issues",
+                "source": "https://github.com/jmespath/jmespath.php/tree/2.8.0"
+            },
+            "time": "2024-09-04T18:46:31+00:00"
         },
         {
             "name": "myclabs/deep-copy",
@@ -4944,6 +5216,76 @@
                 }
             ],
             "time": "2026-01-05T13:30:16+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v8.0.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "reference": "224db910898ce1317b892a9a1338f1f8f17eb7c7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "require-dev": {
+                "symfony/process": "^7.4|^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v8.0.11"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-11T16:39:47+00:00"
         },
         {
             "name": "symfony/finder",

--- a/tests/Unit/Services/Audit/S3DeliveryAdapterTest.php
+++ b/tests/Unit/Services/Audit/S3DeliveryAdapterTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Services\Audit\S3DeliveryAdapter;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
 
 it('builds correct S3 object keys from path prefix and template vars', function (): void {
     $adapter = new S3DeliveryAdapter;
@@ -26,4 +28,53 @@ it('builds correct S3 object key with empty prefix', function (): void {
     $reflection = new ReflectionMethod($adapter, 'resolveKey');
     $key = $reflection->invoke($adapter, '', 'audit.html', []);
     expect($key)->toBe('audit.html');
+});
+
+it('builds an S3 disk per delivery and puts each artefact via flysystem', function (): void {
+    $disk = Mockery::mock(Filesystem::class);
+    $disk->shouldReceive('put')->once()->with('backups/2026/audit.html', 'html-content');
+    $disk->shouldReceive('put')->once()->with('backups/2026/process.jsonl', 'jsonl');
+
+    Storage::shouldReceive('build')->once()->with(Mockery::on(function (array $cfg): bool {
+        return $cfg['driver'] === 's3'
+            && $cfg['key'] === 'AKIA'
+            && $cfg['secret'] === 'shhh'
+            && $cfg['region'] === 'eu-central-1'
+            && $cfg['bucket'] === 'audits'
+            && $cfg['endpoint'] === 'https://minio.local:9000'
+            && $cfg['use_path_style_endpoint'] === true
+            && $cfg['throw'] === true;
+    }))->andReturn($disk);
+
+    $adapter = new S3DeliveryAdapter;
+    $adapter->deliver(
+        ['audit.html' => 'html-content', 'process.jsonl' => 'jsonl'],
+        [
+            'endpoint' => 'https://minio.local:9000',
+            'bucket' => 'audits',
+            'region' => 'eu-central-1',
+            'access_key' => 'AKIA',
+            'secret_key' => 'shhh',
+            'path_prefix' => 'backups/{year}/',
+        ],
+        ['year' => '2026'],
+    );
+});
+
+it('omits endpoint and disables path-style addressing when targeting AWS S3 directly', function (): void {
+    $disk = Mockery::mock(Filesystem::class);
+    $disk->shouldReceive('put')->once()->with('audit.html', 'content');
+
+    Storage::shouldReceive('build')->once()->with(Mockery::on(function (array $cfg): bool {
+        return $cfg['endpoint'] === null
+            && $cfg['use_path_style_endpoint'] === false
+            && $cfg['region'] === 'us-east-1';
+    }))->andReturn($disk);
+
+    $adapter = new S3DeliveryAdapter;
+    $adapter->deliver(
+        ['audit.html' => 'content'],
+        ['bucket' => 'audits', 'access_key' => 'AKIA', 'secret_key' => 'shhh'],
+        [],
+    );
 });


### PR DESCRIPTION
## Summary
- Replace ~80 lines of hand-rolled AWS SigV4 + cURL in \`S3DeliveryAdapter\` with \`Storage::build(['driver' => 's3', ...])->put(\$key, \$content)\`.
- Per-channel disk built at runtime — no static \`s3\` disk needed in \`config/filesystems.php\` since each audit channel has its own creds / bucket / endpoint.
- Add \`league/flysystem-aws-s3-v3 ^3.0\` (pulls \`aws/aws-sdk-php\`, etc.).
- Auto path-style toggle: custom \`endpoint\` set → path-style on (MinIO / Wasabi compat); empty → off (AWS virtual-hosted style).
- Tests: keep 3 reflection tests for \`resolveKey\`; add 2 Mockery-based tests covering disk-build args + put dispatch.

## Stacking
- Based on \`split/composer-deps\` to avoid composer.json / composer.lock conflicts. Merge that PR first (or rebase this onto main once it lands), and GitHub will auto-retarget.

## Test plan
- [ ] \`composer test\` green
- [ ] Configure an audit channel with a real S3 bucket (or MinIO at \`http://localhost:9000\`) and run a cloning job — verify objects land at the expected keys
- [ ] Validate the \`encrypted:\` secret-key path still works
- [ ] Confirm error from a wrong bucket / key surfaces as a thrown exception (no silent failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)