### PR TITLE
ci(build): add missing zip extension for static builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
       # mbregex is a separate SPC extension (not part of mbstring) that provides mb_ereg*
       # and mb_regex_encoding. mPDF checks for it at runtime and fails without it.
       # Adding it here makes SPC auto-pull the onig library via its lib-depends.
-      EXTENSIONS: ctype,curl,fileinfo,filter,gd,iconv,mbstring,mbregex,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,phar,readline,session,sqlite3,tokenizer,zlib
+      EXTENSIONS: ctype,curl,fileinfo,filter,gd,iconv,mbstring,mbregex,openssl,pcntl,pdo,pdo_mysql,pdo_pgsql,pdo_sqlite,phar,readline,session,sqlite3,tokenizer,zlib,zip
       # Optional gd image libs. libpng + zlib are hard-deps and always built;
       # these add JPEG, WebP, and TrueType font support for mpdf-generated PDFs.
       # libavif intentionally omitted (heavy aom/dav1d toolchain, rarely used in PDFs).


### PR DESCRIPTION
This PR adds the missing `zip` PHP extension to the build pipeline.

When using the static build of `clonio`, dumping will successfully finish and then fail when trying to zip it all up. This doesn't happen with the PHAR version if the local PHP installation has `ext-zip` available.

Static build: 

```
Failed to finalise dump archive: ZIP support unavailable — the PHP zip extension is not loaded.
```

PHAR build:

```
[2026-07-12T10:29:18.037692+00:00] INFO: dump_archived {"file":"my_database_20260712_102708.zip","bytes":1649395}
[2026-07-12T10:29:18.037745+00:00] INFO: run_finished {"success":true,"rows":25524}
[2026-07-12T10:29:18.037782+00:00] INFO: key_mapping_cleanup_completed
  Generating audit log .......................................................  ✓
  Delivering via local, stdout, stderr .......................................  ✓

  Tables: 30/30  Rows: 25524  Duration: 2m 9s

  Dump: my_database_20260712_102708.zip  (1.6 MB)
```