### PR TITLE
Docker based Development Setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 APP_KEY=
+# DEV_PHP_VERSION=8.5-dev-macos
+DEV_PHP_VERSION=8.5-dev

--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,6 @@ docker-test: docker-build
 
 docker-shell: docker-build
 	docker run --rm -it -v "$$(pwd)":/workspace --entrypoint sh $(DOCKER_IMAGE)
+
+
+include Makefile.dev.mk

--- a/Makefile.dev.mk
+++ b/Makefile.dev.mk
@@ -1,0 +1,17 @@
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+restart: down up
+
+bash:
+	docker compose exec php bash
+
+test:
+	docker compose exec php bash -c 'XDEBUG_MODE=coverage composer test'
+
+check:
+	docker compose exec php bash -c 'composer lint && composer test:types'
+

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  php:
+    image: "wodby/php:8.5-dev-macos"
+    environment:
+      PHP_EXTENSIONS_DISABLE: 'xhprof,spx'
+    healthcheck:
+      test: ["CMD", "php", "-v"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - .:/var/www/html

--- a/tests/Feature/Commands/InitCommandTest.php
+++ b/tests/Feature/Commands/InitCommandTest.php
@@ -232,40 +232,35 @@ it('does not overwrite existing audit channels on re-init', function (): void {
 
 it('returns an IO error when a new .env cannot be written', function (): void {
     // No APP_KEY anywhere -> the command tries to create a fresh .env.
-    // Making the disk root read-only forces Storage::put() to fail, which
-    // bubbles up as a RuntimeException and is reported as an IO error.
+    // Forcing Storage::put() to return false (as it would on a failed write)
+    // bubbles up as a RuntimeException and is reported as an IO error. We mock
+    // rather than chmod because chmod is a no-op under root (e.g. in Docker).
     putenv('APP_KEY');
     unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
 
-    $root = Storage::path('');
-    chmod($root, 0500);
+    Storage::shouldReceive('exists')->with('.env')->andReturn(false);
+    Storage::shouldReceive('put')->with('.env', Mockery::type('string'))->andReturn(false);
 
-    try {
-        $this->artisan('init')
-            ->expectsOutputToContain('permission denied')
-            ->assertExitCode(ExitCode::IoError->value);
-    } finally {
-        chmod($root, 0755);
-    }
+    $this->artisan('init')
+        ->expectsOutputToContain('permission denied')
+        ->assertExitCode(ExitCode::IoError->value);
 });
 
 it('returns an IO error when an existing .env cannot be overwritten', function (): void {
     // An existing .env without an APP_KEY would normally be appended to, but
-    // making the file itself read-only forces the write to fail.
+    // forcing Storage::put() to return false makes the rewrite fail. We mock
+    // rather than chmod because chmod is a no-op under root (e.g. in Docker).
     putenv('APP_KEY');
     unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
 
-    Storage::put('.env', "DB_HOST=localhost\n");
-    $path = Storage::path('.env');
-    chmod($path, 0400);
+    Storage::shouldReceive('exists')->with('.env')->andReturn(true);
+    Storage::shouldReceive('get')->with('.env')->andReturn("DB_HOST=localhost\n");
+    Storage::shouldReceive('path')->with('.env')->andReturn('/tmp/clonio-readonly.env');
+    Storage::shouldReceive('put')->with('.env', Mockery::type('string'))->andReturn(false);
 
-    try {
-        $this->artisan('init')
-            ->expectsOutputToContain('permission denied')
-            ->assertExitCode(ExitCode::IoError->value);
-    } finally {
-        chmod($path, 0644);
-    }
+    $this->artisan('init')
+        ->expectsOutputToContain('permission denied')
+        ->assertExitCode(ExitCode::IoError->value);
 });
 
 it('returns an IO error when an existing .env cannot be read', function (): void {


### PR DESCRIPTION
## Summary

Containerized local dev setup (Docker Compose + `make` targets) so clonio-cli
builds/runs/tests without a host PHP toolchain, and makes the `init` IO-error
tests pass under the container's root user.

> **Stacked PR — base: `main`** · 1st of 6 · Part of #164 (series overview).
> Pure tooling, no runtime behavior — safe to merge or skip independently.

## Motivation

Contributors otherwise need a matching PHP 8.x + extensions setup. A throwaway
container removes that friction and gives everyone the same `composer test` /
`composer lint` environment.

## What's changed

- **`compose.yaml`** — one `php` service (`wodby/php:8.5`), repo bind-mounted at
  `/var/www/html`, `php -v` healthcheck.
- **`Makefile.dev.mk`** (+ hook in **`Makefile`**) — `make up`/`down`/`restart`/
  `bash`, `make test` (`XDEBUG_MODE=coverage composer test`), `make check`
  (`composer lint && composer test:types`).
- **`.env.example`** — `APP_KEY` + `DEV_PHP_VERSION` hint.
- **`tests/Feature/Commands/InitCommandTest.php`** — the two "cannot write .env"
  IO-error tests simulated a read-only disk with `chmod`, a **no-op under root**
  (the container), so they failed there; they now mock `Storage::put()` returning
  `false` — user-independent, same error path.

## Testing

`make up && make test` — full suite green in the container.
