### PR TITLE
Fix Transformation Strategy 'null'

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,3 @@
 APP_KEY=
+# DEV_PHP_VERSION=8.5-dev-macos
+DEV_PHP_VERSION=8.5-dev

--- a/Makefile
+++ b/Makefile
@@ -122,3 +122,6 @@ docker-test: docker-build
 
 docker-shell: docker-build
 	docker run --rm -it -v "$$(pwd)":/workspace --entrypoint sh $(DOCKER_IMAGE)
+
+
+include Makefile.dev.mk

--- a/Makefile.dev.mk
+++ b/Makefile.dev.mk
@@ -1,0 +1,17 @@
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+restart: down up
+
+bash:
+	docker compose exec php bash
+
+test:
+	docker compose exec php bash -c 'XDEBUG_MODE=coverage composer test'
+
+check:
+	docker compose exec php bash -c 'composer lint && composer test:types'
+

--- a/app/Commands/Cloning/DumpCommand.php
+++ b/app/Commands/Cloning/DumpCommand.php
@@ -40,6 +40,7 @@ class DumpCommand extends Command
         {--drop-unknown-tables   : Set drop_unknown_tables: true in the generated YAML}
         {--drop-extra-columns    : Set drop_extra_columns: true in the generated YAML}
         {--no-disable-fk-checks  : Set disable_foreign_key_checks: false in the generated YAML}
+        {--skip-remapping-keys   : Set remap_keys: false in the generated YAML}
         {--ci                    : CI mode — suppress non-error output}';
 
     /**
@@ -245,6 +246,7 @@ class DumpCommand extends Command
         $dropUnknownTables = (bool) $this->option('drop-unknown-tables');
         $dropExtraColumns = (bool) $this->option('drop-extra-columns');
         $disableForeignKeyChecks = ! $this->option('no-disable-fk-checks');
+        $remapKeys = ! (bool) $this->option('skip-remapping-keys');
 
         if (! $ci) {
             $this->line('  Transfer options:');
@@ -252,6 +254,7 @@ class DumpCommand extends Command
             $dropUnknownTables = $this->confirm('    Drop unknown tables on target?', $dropUnknownTables);
             $dropExtraColumns = $this->confirm('    Drop extra columns on target?', $dropExtraColumns);
             $disableForeignKeyChecks = $this->confirm('    Disable foreign key checks?', $disableForeignKeyChecks);
+            $remapKeys = $this->confirm('    Remap keys?', $remapKeys);
             $this->line('');
         }
 
@@ -269,6 +272,7 @@ class DumpCommand extends Command
             dropUnknownTables: $dropUnknownTables,
             dropExtraColumns: $dropExtraColumns,
             disableForeignKeyChecks: $disableForeignKeyChecks,
+            remapKeys: $remapKeys,
         );
 
         // 12. Write YAML

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -10,7 +10,9 @@ use App\Data\Cloning\ColumnCloningConfigData;
 use App\Data\Cloning\DryRunResultData;
 use App\Data\Cloning\DryRunTableData;
 use App\Data\Cloning\KeyRemappingConfigData;
+use App\Data\Cloning\StatsTableTransferData;
 use App\Data\Cloning\TableCloningConfigData;
+use App\Data\Cloning\TableRunPhase;
 use App\Data\Cloning\TableRunResultData;
 use App\Data\Cloning\TableRunStatus;
 use App\Data\ConnectionData;
@@ -55,6 +57,11 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use LaravelZero\Framework\Commands\Command;
 use RuntimeException;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Helper\TableSeparator;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Yaml\Yaml;
 use Throwable;
@@ -103,10 +110,29 @@ class RunCommand extends Command
         $verbosity = $this->getOutput()->getVerbosity();
         $isVerbose = $verbosity >= OutputInterface::VERBOSITY_VERBOSE;
         $isVeryVerbose = $verbosity >= OutputInterface::VERBOSITY_VERY_VERBOSE;
+        $isDebug = $verbosity >= OutputInterface::VERBOSITY_DEBUG;
+
+        // Live nested progress bars are driven by verbosity on an interactive TTY:
+        // `-v` shows the bars (compact), `-vv` adds full per-phase throughput to the
+        // per-table bar, `-vvv` additionally prints the per-table timing summary.
+        $out = $this->output->getOutput();
+        $showProgress = $isVerbose
+            && ! $ci
+            && $this->output->isDecorated()
+            && $out instanceof ConsoleOutput;
 
         // Map Symfony verbosity to stderr log threshold so `-v` / `-vv` surface
-        // info / debug events on stderr without needing a separate live-output path.
-        $stderrLevel = $isVeryVerbose ? 'debug' : ($isVerbose ? 'info' : ($ci ? 'error' : 'warning'));
+        // info / debug events on stderr when piped. When the bars are live they own
+        // the terminal, so the stderr stream is silenced to avoid corrupting them —
+        // skips/failures still surface as result lines and in the final summary.
+        // (Set before the channel is first resolved, so it actually takes effect.)
+        $stderrLevel = match (true) {
+            $showProgress => 'emergency',
+            $isVeryVerbose => 'debug',
+            $isVerbose => 'info',
+            $ci => 'error',
+            default => 'warning',
+        };
         config(['logging.channels.stderr.level' => $stderrLevel]);
 
         $step = new VerboseStepRenderer($this->output, $ci);
@@ -428,6 +454,23 @@ class RunCommand extends Command
         $dotColumn = 0;
         $maxDotColumns = 70;
 
+        $overallBar = null;
+        $tableBar = null;
+        $logSection = null;
+
+        if ($showProgress) {
+            // Live bars own the terminal: every write must go through a section, or
+            // Symfony's cursor math desyncs and re-prints the bars. Sections created
+            // first render higher up — the results log on top, the per-table bar in
+            // the middle, the overall bar pinned at the bottom. All reused for the run.
+            $logSection = $out->section();
+            $tableBar = new ProgressBar($out->section());
+            $overallBar = new ProgressBar($out->section());
+            // Leading newline keeps a blank line between the per-table bar and the
+            // overall bar (the section owns both lines, so it stays stable on redraw).
+            $overallBar->setFormat("\n  <info>tables</info>  [%bar%] %current%/%max%");
+        }
+
         $dumpSink = $targetIsDump
             ? new SqlDumpService(new DumpDialectFactory, new DumpArchiver)
             : null;
@@ -440,68 +483,105 @@ class RunCommand extends Command
             skipSchema: $skipSchema,
             skipTables: $skipTables,
             onlyTables: $onlyTables,
-            onProgress: function (string $tableName, TableRunStatus $status, int $rows, int $skipped, array $skippedRows) use ($step, $isVerbose, $ci, &$notFoundTables, &$schemaFailureTables, &$dotColumn, $maxDotColumns): void {
-                if ($ci) {
-                    if ($status === TableRunStatus::NotFound) {
-                        $notFoundTables[] = $tableName;
-                    } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
-                        $schemaFailureTables[] = $tableName;
-                    }
-
-                    return;
-                }
-
-                if ($isVerbose) {
-                    if ($status === TableRunStatus::Transferred) {
-                        $suffix = sprintf('(%s rows%s)', number_format($rows), $skipped > 0 ? ', '.$skipped.' skipped' : '');
-                        $step->success($suffix);
-                        $this->renderSkipGroups($step, $skippedRows);
-                    } elseif ($status === TableRunStatus::Failed) {
-                        $step->fail();
-                        $this->renderSkipGroups($step, $skippedRows);
-                    } elseif ($status === TableRunStatus::NotFound) {
-                        $this->line(sprintf('  <comment>?</comment>  %s  — not found in source, skipped', $tableName));
-                        $notFoundTables[] = $tableName;
-                    } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
-                        $this->line(sprintf('  <error>S</error>  %s  — schema replication failed, skipped', $tableName));
-                        $schemaFailureTables[] = $tableName;
-                    }
-
-                    return;
-                }
-
-                // Normal mode: dot indicators wrapped at 70 chars
+            onProgress: function (string $tableName, TableRunStatus $status, int $rows, int $skipped, array $skippedRows, ?StatsTableTransferData $timings = null) use ($isVerbose, $isVeryVerbose, $isDebug, $ci, &$notFoundTables, &$schemaFailureTables, &$dotColumn, $maxDotColumns, $showProgress, $overallBar, $tableBar, $logSection): void {
+                // Record pre-skip outcomes for the final summary (every mode).
                 if ($status === TableRunStatus::NotFound) {
                     $notFoundTables[] = $tableName;
                 } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
                     $schemaFailureTables[] = $tableName;
                 }
 
-                $indicator = match ($status) {
-                    TableRunStatus::Transferred => $skipped > 0 ? 'F' : '.',
-                    TableRunStatus::Failed => 'E',
-                    TableRunStatus::NotFound => '?',
-                    TableRunStatus::SkippedBySchemaFailure => 'S',
-                    default => null,
-                };
+                if ($ci) {
+                    return;
+                }
 
-                if ($indicator !== null) {
-                    $this->output->write($indicator);
-                    $dotColumn++;
-
-                    if ($dotColumn >= $maxDotColumns) {
-                        $this->output->writeln('');
-                        $dotColumn = 0;
+                if ($status === TableRunStatus::InProgress) {
+                    if ($showProgress && $timings instanceof StatsTableTransferData) {
+                        $this->advanceTableBar($tableBar, $timings, $isVeryVerbose);
                     }
+
+                    return;
+                }
+
+                // ── Terminal status ──
+                // Quiet mode (not verbose): compact one-char dot indicators.
+                if (! $isVerbose) {
+                    $indicator = match ($status) {
+                        TableRunStatus::Transferred => $skipped > 0 ? 'F' : '.',
+                        TableRunStatus::Failed => 'E',
+                        TableRunStatus::NotFound => '?',
+                        TableRunStatus::SkippedBySchemaFailure => 'S',
+                        default => null,
+                    };
+
+                    if ($indicator !== null) {
+                        $this->output->write($indicator);
+                        $dotColumn++;
+
+                        if ($dotColumn >= $maxDotColumns) {
+                            $this->output->writeln('');
+                            $dotColumn = 0;
+                        }
+                    }
+
+                    return;
+                }
+
+                // Verbose. Scrolling detail goes to the log section when bars are live
+                // (so it never corrupts them), otherwise straight to the console.
+                $sink = $showProgress ? $logSection : $this->output;
+
+                // Only Transferred/Failed tables ever started a per-table bar
+                // (via onTableStart); NotFound/SchemaFailure never did.
+                if ($showProgress && ($status === TableRunStatus::Transferred || $status === TableRunStatus::Failed)) {
+                    $tableBar->finish();
+                }
+
+                $suffix = $skipped > 0 ? ', '.number_format($skipped).' skipped' : '';
+
+                if ($status === TableRunStatus::Transferred) {
+                    $sink->writeln(sprintf('  <info>✓</info>  %s  (%s rows%s)', $tableName, number_format($rows), $suffix));
+                } elseif ($status === TableRunStatus::Failed) {
+                    $sink->writeln(sprintf('  <error>✗</error>  %s  — transfer failed', $tableName));
+                } elseif ($status === TableRunStatus::NotFound) {
+                    $sink->writeln(sprintf('  <comment>?</comment>  %s  — not found in source, skipped', $tableName));
+                } elseif ($status === TableRunStatus::SkippedBySchemaFailure) {
+                    $sink->writeln(sprintf('  <error>S</error>  %s  — schema replication failed, skipped', $tableName));
+                }
+
+                if ($status === TableRunStatus::Transferred || $status === TableRunStatus::Failed) {
+                    $this->renderSkipGroups($sink, $skippedRows);
+
+                    // `-vvv`: per-table timing summary table.
+                    if ($isDebug && $timings instanceof StatsTableTransferData) {
+                        $this->renderTimingSummary($sink, $timings);
+                    }
+                }
+
+                if ($showProgress) {
+                    $overallBar->advance();
                 }
             },
             keyRemapping: $keyRemappingService,
             breakOnFailure: (bool) $this->option('break-on-failure'),
-            onTableStart: $isVerbose && ! $ci
-                ? fn (string $tableName) => $step->start('  '.$tableName)
-                : null,
+            onTableStart: $showProgress
+                ? function (string $tableName) use ($tableBar): void {
+                    $this->startTableBar($tableBar, $tableName);
+                }
+            : null,
             dumpSink: $dumpSink,
+            onStart: $showProgress
+                ? function (int $totalTables) use ($overallBar): void {
+                    $overallBar->setMaxSteps($totalTables);
+                    $overallBar->start();
+                }
+            : null,
+            trackRowTotals: $showProgress,
         );
+
+        if ($overallBar instanceof ProgressBar) {
+            $overallBar->finish();
+        }
 
         $finishedAt = new DateTimeImmutable('now', new DateTimeZone('UTC'));
 
@@ -663,6 +743,21 @@ class RunCommand extends Command
                 count($schemaFailureTables) === 1 ? '' : 's',
                 implode(', ', $schemaFailureTables),
             ));
+        }
+
+        // Data-transfer failures with their reason. In live-bar mode the ✗ line is
+        // terse and the stderr log is silenced, so surface the reason here.
+        $failedTables = array_values(array_filter($result->tables, static fn (TableRunResultData $t): bool => $t->status === TableRunStatus::Failed));
+
+        if ($failedTables !== []) {
+            $this->line('');
+            foreach ($failedTables as $failedTable) {
+                $this->line(sprintf(
+                    '  <error>Error: table %s failed%s</error>',
+                    $failedTable->tableName,
+                    $failedTable->failureReason !== null ? ' — '.$failedTable->failureReason : '',
+                ));
+            }
         }
 
         $transferredCount = count(array_filter($result->tables, static fn (TableRunResultData $t): bool => $t->status === TableRunStatus::Transferred));
@@ -974,9 +1069,153 @@ class RunCommand extends Command
     }
 
     /**
+     * (Re)initialise the nested per-table progress bar for a new table. The row
+     * total is not known yet (it arrives with the first activity or loop event),
+     * so the bar starts in the indeterminate format. The `%message%` slot carries
+     * the one-shot activity first, then per-chunk throughput.
+     */
+    private function startTableBar(ProgressBar $bar, string $tableName): void
+    {
+        $bar->setFormat('  %table%  [%bar%]  %message%');
+        $bar->setMessage($tableName, 'table');
+        $bar->setMessage('', 'message');
+        $bar->start(0);
+    }
+
+    /**
+     * Advance the per-table bar from a chunk's cumulative timings. On the first
+     * event with a known row total it switches to the determinate bar format.
+     */
+    private function advanceTableBar(ProgressBar $bar, StatsTableTransferData $stats, bool $verbose): void
+    {
+        $isOneShot = $stats->status?->isOneShot();
+
+        $message = match ($isOneShot) {
+            true => $this->formatStatus($stats),
+            false => $this->formatProgress($stats, $verbose),
+            null => ''
+        };
+
+        $bar->setMessage($message, 'message');
+
+        if ($isOneShot) {
+            $bar->display();
+
+            return;
+        }
+
+        if ($stats->totalRows > 0) {
+            if ($bar->getMaxSteps() !== $stats->totalRows) {
+                $bar->setMaxSteps($stats->totalRows);
+                $bar->setFormat('  %table%  [%bar%] %current%/%max% (%percent:3s%%)  %message%');
+            }
+
+            $bar->setProgress(min($stats->rowsProcessed, $stats->totalRows));
+
+            return;
+        }
+
+        $bar->setProgress($stats->rowsProcessed);
+    }
+
+    private function formatStatus(StatsTableTransferData $stats): string
+    {
+        return $stats->status instanceof TableRunPhase ? $stats->status->label().'…' : '';
+    }
+
+    /**
+     * Throughput text shown on the per-table bar: overall only in default mode,
+     * full per-phase breakdown in verbose mode.
+     */
+    private function formatProgress(StatsTableTransferData $stats, bool $verbose): string
+    {
+        $overall = trim($this->formatThroughput($stats->loopAggregate->latestSecondsPerMillionRows));
+
+        if (! $verbose) {
+            return $overall === '—' ? '' : $overall;
+        }
+
+        return sprintf(
+            'all %s · sel %s · tr %s · ins %s',
+            $overall,
+            trim($this->formatThroughput($stats->selectAggregate->latestSecondsPerMillionRows)),
+            trim($this->formatThroughput($stats->transformAggregate->latestSecondsPerMillionRows)),
+            trim($this->formatThroughput($stats->insertAggregate->latestSecondsPerMillionRows)),
+        );
+    }
+
+    private function renderTimingSummary(OutputInterface $sink, StatsTableTransferData $timings): void
+    {
+        if ($timings->loops->isEmpty()) {
+            return;
+        }
+
+        $rows = [];
+
+        foreach (TableRunPhase::cases() as $phase) {
+            $agg = $timings->aggregate($phase);
+            if ($agg->count === 0) {
+                continue;
+            }
+
+            if ($phase === TableRunPhase::Loop || $phase === TableRunPhase::Select) {
+                $rows[] = new TableSeparator;
+            }
+
+            $rows[] = [
+                $phase->value,
+                (string) $agg->count,
+                $this->formatSeconds($agg->min ?? 0.0),
+                $this->formatSeconds($agg->max ?? 0.0),
+                $this->formatSeconds($agg->averageSeconds ?? 0.0),
+                $this->formatSeconds($agg->sum),
+                $this->formatThroughput($agg->secondsPerMillionRows),
+            ];
+        }
+
+        $indent = str_repeat(' ', 6);
+        $sink->writeln(sprintf('%s── timing summary ──', $indent));
+        $buffer = new BufferedOutput(
+            $this->output->getVerbosity(),
+            $this->output->isDecorated(),
+            $this->output->getFormatter(),
+        );
+        $table = new Table($buffer);
+        $table->setHeaders(['phase', 'chunks', 'min', 'max', 'avg', 'total', 's/1M rows']);
+        $table->setRows($rows);
+        $table->render();
+
+        foreach (explode("\n", rtrim($buffer->fetch(), "\n")) as $line) {
+            $sink->writeln($indent.$line);
+        }
+    }
+
+    private function formatSeconds(float $seconds): string
+    {
+        if ($seconds < 1.0) {
+            return sprintf('%6.1f ms', $seconds * 1000.0);
+        }
+
+        return sprintf('%5.1f s', $seconds);
+    }
+
+    private function formatThroughput(?float $secondsPerMillion): string
+    {
+        if ($secondsPerMillion === null) {
+            return '—';
+        }
+
+        if ($secondsPerMillion >= 1.0) {
+            return sprintf('%5.1f s/M', $secondsPerMillion);
+        }
+
+        return sprintf('%5.1f ms/M', $secondsPerMillion * 1000.0);
+    }
+
+    /**
      * @param  list<SkippedRow>  $skippedRows
      */
-    private function renderSkipGroups(VerboseStepRenderer $step, array $skippedRows): void
+    private function renderSkipGroups(OutputInterface $sink, array $skippedRows): void
     {
         if ($skippedRows === []) {
             return;
@@ -985,12 +1224,12 @@ class RunCommand extends Command
         $groups = $this->aggregateSkipReasons($skippedRows);
         $shown = array_slice($groups, 0, 10);
         foreach ($shown as $group) {
-            $step->note(sprintf('     └ %d× %s', $group['count'], $group['message']));
+            $sink->writeln(sprintf('     └ %d× %s', $group['count'], $group['message']));
         }
 
         $rest = count($groups) - count($shown);
         if ($rest > 0) {
-            $step->note(sprintf('     └ … and %d more error types', $rest));
+            $sink->writeln(sprintf('     └ … and %d more error types', $rest));
         }
     }
 

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -227,6 +227,7 @@ class RunCommand extends Command
                     dropExtraColumns: $dropExtOverride ?? $opts->dropExtraColumns,
                     disableForeignKeyChecks: $fkChecksOverride ?? $opts->disableForeignKeyChecks,
                     fakerLocale: $opts->fakerLocale,
+                    remapKeys: $opts->remapKeys,
                 ),
                 tables: $config->tables,
                 keyRemapping: $config->keyRemapping,
@@ -377,7 +378,7 @@ class RunCommand extends Command
 
         // ─── Phase 5b: Key Mapping Generation ─────────────────────────────────
         $keyRemappingService = null;
-        $skipRemapping = (bool) $this->option('skip-remapping-keys');
+        $skipRemapping = (bool) $this->option('skip-remapping-keys') || ! $config->options->remapKeys;
         $keyRemappingConfig = $config->keyRemapping;
 
         if ($keyRemappingConfig instanceof KeyRemappingConfigData && $keyRemappingConfig->isActive() && ! $skipRemapping) {

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -1021,6 +1021,13 @@ class RunCommand extends Command
             return sprintf('%.0fs', $seconds);
         }
 
+        if ($seconds >= 3600) {
+            $hours = (int) ($seconds / 3600);
+            $minutes = (int) (fmod($seconds, 3600) / 60);
+
+            return sprintf('%dh %dm', $hours, $minutes);
+        }
+
         $minutes = (int) ($seconds / 60);
         $remaining = $seconds % 60;
 
@@ -1124,23 +1131,25 @@ class RunCommand extends Command
     }
 
     /**
-     * Throughput text shown on the per-table bar: overall only in default mode,
-     * full per-phase breakdown in verbose mode.
+     * Progress detail shown on the per-table bar: ETA plus the overall pace in every
+     * verbose mode, expanded to the full per-phase pace breakdown in very verbose mode.
      */
     private function formatProgress(StatsTableTransferData $stats, bool $verbose): string
     {
-        $overall = trim($this->formatThroughput($stats->loopAggregate->latestSecondsPerMillionRows));
+        $eta = 'ETA '.$this->formatDuration($stats->estimatedSecondsRemaining);
+        $overall = trim($this->formatThroughput($stats->loopAggregate->latestPacePerMillion));
 
         if (! $verbose) {
-            return $overall === '—' ? '' : $overall;
+            return $overall === '—' ? $eta : $eta.' · '.$overall;
         }
 
         return sprintf(
-            'all %s · sel %s · tr %s · ins %s',
+            '%s · all %s · sel %s · tr %s · ins %s',
+            $eta,
             $overall,
-            trim($this->formatThroughput($stats->selectAggregate->latestSecondsPerMillionRows)),
-            trim($this->formatThroughput($stats->transformAggregate->latestSecondsPerMillionRows)),
-            trim($this->formatThroughput($stats->insertAggregate->latestSecondsPerMillionRows)),
+            trim($this->formatThroughput($stats->selectAggregate->latestPacePerMillion)),
+            trim($this->formatThroughput($stats->transformAggregate->latestPacePerMillion)),
+            trim($this->formatThroughput($stats->insertAggregate->latestPacePerMillion)),
         );
     }
 
@@ -1169,7 +1178,7 @@ class RunCommand extends Command
                 $this->formatSeconds($agg->max ?? 0.0),
                 $this->formatSeconds($agg->averageSeconds ?? 0.0),
                 $this->formatSeconds($agg->sum),
-                $this->formatThroughput($agg->secondsPerMillionRows),
+                $this->formatThroughput($agg->pacePerMillion),
             ];
         }
 

--- a/app/Commands/Cloning/RunCommand.php
+++ b/app/Commands/Cloning/RunCommand.php
@@ -41,6 +41,7 @@ use App\Services\Cloning\CloningYamlValidator;
 use App\Services\Cloning\EncryptedFileKeyRemappingStore;
 use App\Services\Cloning\KeyRemappingService;
 use App\Services\Cloning\SkippedRow;
+use App\Services\Cloning\TableConfigResolver;
 use App\Services\Config\ConfigService;
 use App\Services\Database\DatabaseConnectionService;
 use App\Services\Output\VerboseStepRenderer;
@@ -105,6 +106,7 @@ class RunCommand extends Command
         SchemaInspector $inspector,
         CloningRunOrchestrator $orchestrator,
         AuditBuffer $auditBuffer,
+        TableConfigResolver $tableResolver,
     ): int {
         $ci = (bool) $this->option('ci');
         $verbosity = $this->getOutput()->getVerbosity();
@@ -364,6 +366,14 @@ class RunCommand extends Command
 
             return ExitCode::ConnectionError->value;
         }
+
+        // Expand regex table keys against the real source schema. From here on
+        // $config->tables carry concrete table names, so the orchestrator, key
+        // mapping and audit code all keep working against literal names.
+        $config = $tableResolver->resolve($config, $sourceSchema);
+        // Regex keys may have expanded rows.strategy: skip / skip patterns into
+        // concrete names — re-merge them into the skip list.
+        $skipTables = array_values(array_unique(array_merge($skipTables, $config->skipTables)));
 
         // ─── Phase 5b: Key Mapping Generation ─────────────────────────────────
         $keyRemappingService = null;

--- a/app/Data/Cloning/CloningOptionsData.php
+++ b/app/Data/Cloning/CloningOptionsData.php
@@ -13,5 +13,6 @@ final readonly class CloningOptionsData
         public bool $dropExtraColumns,
         public bool $disableForeignKeyChecks,
         public string $fakerLocale,
+        public bool $remapKeys = true,
     ) {}
 }

--- a/app/Data/Cloning/DumpResultData.php
+++ b/app/Data/Cloning/DumpResultData.php
@@ -20,5 +20,6 @@ final readonly class DumpResultData
         public bool $dropUnknownTables = false,
         public bool $dropExtraColumns = false,
         public bool $disableForeignKeyChecks = true,
+        public bool $remapKeys = true,
     ) {}
 }

--- a/app/Data/Cloning/StatsLoopData.php
+++ b/app/Data/Cloning/StatsLoopData.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Cloning;
+
+/**
+ * Snapshot of a single chunk-loop iteration inside `transferTable()`.
+ *
+ * `rowsDone` and `rowsSkipped` count rows for **this loop only**, not
+ * cumulative — inspect the parent `StatsTableTransferData` for
+ * cumulative progress.
+ */
+final readonly class StatsLoopData
+{
+    public function __construct(
+        public int $loopIndex,
+        public int $chunkRows,
+        public float $selectSeconds,
+        public float $transformSeconds,
+        public float $insertSeconds,
+        public float $overallSeconds,
+        public int $rowsDone,
+        public int $rowsSkipped,
+        public int $totalRows,
+    ) {}
+}

--- a/app/Data/Cloning/StatsLoopSnapshotData.php
+++ b/app/Data/Cloning/StatsLoopSnapshotData.php
@@ -20,9 +20,9 @@ final readonly class StatsLoopSnapshotData
         public int $rowsDoneCumulative,
         public int $rowsSkippedCumulative,
         public ?float $percentComplete,
-        public ?float $selectSecondsPerMillionRows,
-        public ?float $transformSecondsPerMillionRows,
-        public ?float $insertSecondsPerMillionRows,
-        public ?float $loopSecondsPerMillionRows,
+        public ?float $selectPacePerMillion,
+        public ?float $transformPacePerMillion,
+        public ?float $insertPacePerMillion,
+        public ?float $loopPacePerMillion,
     ) {}
 }

--- a/app/Data/Cloning/StatsLoopSnapshotData.php
+++ b/app/Data/Cloning/StatsLoopSnapshotData.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Cloning;
+
+/**
+ * Immutable scalar snapshot captured after a chunk loop is recorded.
+ * Consumers can iterate `StatsTableTransferData::$statsOverTime` to observe
+ * how cumulative progress and per-phase throughput evolve across loops.
+ *
+ * Only scalars are stored (not references to the mutable aggregates), so a
+ * snapshot is intrinsically immutable and cheap to retain per loop.
+ */
+final readonly class StatsLoopSnapshotData
+{
+    public function __construct(
+        public int $loopIndex,
+        public int $loopsRecorded,
+        public int $rowsDoneCumulative,
+        public int $rowsSkippedCumulative,
+        public ?float $percentComplete,
+        public ?float $selectSecondsPerMillionRows,
+        public ?float $transformSecondsPerMillionRows,
+        public ?float $insertSecondsPerMillionRows,
+        public ?float $loopSecondsPerMillionRows,
+    ) {}
+}

--- a/app/Data/Cloning/StatsPhaseAggregateData.php
+++ b/app/Data/Cloning/StatsPhaseAggregateData.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Cloning;
+
+/**
+ * Mutable running aggregate for a single per-chunk timing phase. Updated
+ * in O(1) via `record()`; derived throughput figures are exposed as
+ * virtual (computed) properties.
+ */
+final class StatsPhaseAggregateData
+{
+    public private(set) int $count = 0;
+
+    public private(set) float $sum = 0.0;
+
+    public private(set) ?float $min = null;
+
+    public private(set) ?float $max = null;
+
+    public private(set) ?float $last = null;
+
+    public private(set) ?int $lastRows = null;
+
+    public private(set) int $rowsProcessed = 0;
+
+    /** Mean seconds per sample, or null when no sample has been recorded. */
+    public ?float $averageSeconds {
+        get => $this->count > 0 ? $this->sum / $this->count : null;
+    }
+
+    /**
+     * Aggregate seconds per 1,000,000 rows across all samples,
+     * or null when no rows have been processed.
+     */
+    public ?float $secondsPerMillionRows {
+        get => $this->rowsProcessed > 0
+            ? ($this->sum / $this->rowsProcessed) * 1_000_000.0
+            : null;
+    }
+
+    /** Latest-sample seconds per 1,000,000 rows, or null when unavailable. */
+    public ?float $latestSecondsPerMillionRows {
+        get => $this->last !== null && $this->lastRows !== null && $this->lastRows > 0
+            ? ($this->last / $this->lastRows) * 1_000_000.0
+            : null;
+    }
+
+    public static function withRecord(float $seconds, int $rows): self
+    {
+        $instance = new self;
+
+        $instance->record($seconds, $rows);
+
+        return $instance;
+    }
+
+    public function record(float $seconds, int $rows): void
+    {
+        $this->count++;
+        $this->sum += $seconds;
+        $this->min = $this->min === null ? $seconds : min($this->min, $seconds);
+        $this->max = $this->max === null ? $seconds : max($this->max, $seconds);
+        $this->last = $seconds;
+        $this->lastRows = $rows;
+        $this->rowsProcessed += max(0, $rows);
+    }
+}

--- a/app/Data/Cloning/StatsPhaseAggregateData.php
+++ b/app/Data/Cloning/StatsPhaseAggregateData.php
@@ -31,19 +31,35 @@ final class StatsPhaseAggregateData
     }
 
     /**
+     * Aggregate seconds per row across all samples,
+     * or null when no rows have been processed.
+     */
+    public ?float $pace {
+        get => $this->rowsProcessed > 0
+            ? ($this->sum / $this->rowsProcessed)
+            : null;
+    }
+
+    /**
      * Aggregate seconds per 1,000,000 rows across all samples,
      * or null when no rows have been processed.
      */
-    public ?float $secondsPerMillionRows {
-        get => $this->rowsProcessed > 0
-            ? ($this->sum / $this->rowsProcessed) * 1_000_000.0
+    public ?float $pacePerMillion {
+        get => ($pace = $this->pace) !== null
+            ? $pace * 1_000_000.0
+            : null;
+    }
+
+    public ?float $latestPace {
+        get => $this->last !== null && $this->lastRows !== null && $this->lastRows > 0
+            ? $this->last / $this->lastRows
             : null;
     }
 
     /** Latest-sample seconds per 1,000,000 rows, or null when unavailable. */
-    public ?float $latestSecondsPerMillionRows {
-        get => $this->last !== null && $this->lastRows !== null && $this->lastRows > 0
-            ? ($this->last / $this->lastRows) * 1_000_000.0
+    public ?float $latestPacePerMillion {
+        get => ($pace = $this->latestPace) !== null
+            ? $pace * 1_000_000.0
             : null;
     }
 

--- a/app/Data/Cloning/StatsTableTransferData.php
+++ b/app/Data/Cloning/StatsTableTransferData.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Cloning;
+
+use Illuminate\Support\Collection;
+
+/**
+ * Per-table timing container. One instance travels through every chunk
+ * loop of a single `transferTable()` invocation.
+ *
+ * Loops are pushed via `recordLoop(StatsLoopData)`; per-phase running
+ * aggregates (`selectAggregate` / `transformAggregate` / `insertAggregate`)
+ * are updated in O(1) so the derived throughput figures never re-scan
+ * `$loops`.
+ */
+final class StatsTableTransferData
+{
+    public private(set) ?TableRunPhase $status = null;
+
+    /** Wall-clock seconds for each one-shot phase; null until (and unless) it runs. */
+    public private(set) ?float $countingRowsSeconds = null;
+
+    public private(set) ?float $disableFkSeconds = null;
+
+    public private(set) ?float $clearTableSeconds = null;
+
+    /** @var Collection<int, StatsLoopData> */
+    public private(set) Collection $loops;
+
+    /** @var Collection<int, StatsLoopSnapshotData> */
+    public private(set) Collection $statsOverTime;
+
+    public private(set) int $totalRows = 0;
+
+    public private(set) int $rowsDone = 0;
+
+    public private(set) int $rowsSkipped = 0;
+
+    /** Rows accounted for so far (transferred + skipped). */
+    public int $rowsProcessed {
+        get => $this->rowsDone + $this->rowsSkipped;
+    }
+
+    /** Rows still outstanding against `totalRows` (never negative). */
+    public int $rowsRemaining {
+        get => max(0, $this->totalRows - $this->rowsProcessed);
+    }
+
+    /** Completion ratio in the range [0, 100], or null when the total is unknown. */
+    public ?float $percentComplete {
+        get => $this->totalRows > 0
+            ? min(100.0, ($this->rowsProcessed / $this->totalRows) * 100.0)
+            : null;
+    }
+
+    public private(set) StatsPhaseAggregateData $selectAggregate;
+
+    public private(set) StatsPhaseAggregateData $transformAggregate;
+
+    public private(set) StatsPhaseAggregateData $insertAggregate;
+
+    /**
+     * Per-loop aggregate over each chunk's wall-clock time
+     * (`StatsLoopData::$overallSeconds`, rows = chunkRows). Useful for
+     * loop throughput including inter-phase overhead.
+     */
+    public private(set) StatsPhaseAggregateData $loopAggregate;
+
+    public function __construct()
+    {
+        $this->loops = new Collection;
+        $this->statsOverTime = new Collection;
+        $this->selectAggregate = new StatsPhaseAggregateData;
+        $this->transformAggregate = new StatsPhaseAggregateData;
+        $this->insertAggregate = new StatsPhaseAggregateData;
+        $this->loopAggregate = new StatsPhaseAggregateData;
+    }
+
+    public function setStatus(TableRunPhase $status): void
+    {
+        $this->status = $status;
+    }
+
+    public function setTotalRows(int $totalRows): void
+    {
+        $this->totalRows = max(0, $totalRows);
+    }
+
+    public function recordCountingRows(float $seconds): void
+    {
+        $this->countingRowsSeconds = $seconds;
+    }
+
+    public function recordDisableFk(float $seconds): void
+    {
+        $this->disableFkSeconds = $seconds;
+    }
+
+    public function recordClearTable(float $seconds): void
+    {
+        $this->clearTableSeconds = $seconds;
+    }
+
+    /**
+     * Append a completed chunk loop, update running aggregates in O(1),
+     * and append a stats-over-time snapshot.
+     */
+    public function recordLoop(StatsLoopData $loop): void
+    {
+        $this->loops->push($loop);
+
+        $this->selectAggregate->record($loop->selectSeconds, $loop->chunkRows);
+        $this->transformAggregate->record($loop->transformSeconds, $loop->chunkRows);
+        $this->insertAggregate->record($loop->insertSeconds, $loop->chunkRows);
+        $this->loopAggregate->record($loop->overallSeconds, $loop->chunkRows);
+
+        $this->rowsDone += $loop->rowsDone;
+        $this->rowsSkipped += $loop->rowsSkipped;
+
+        $this->statsOverTime->push(new StatsLoopSnapshotData(
+            loopIndex: $loop->loopIndex,
+            loopsRecorded: $this->loops->count(),
+            rowsDoneCumulative: $this->rowsDone,
+            rowsSkippedCumulative: $this->rowsSkipped,
+            percentComplete: $this->percentComplete,
+            selectSecondsPerMillionRows: $this->selectAggregate->secondsPerMillionRows,
+            transformSecondsPerMillionRows: $this->transformAggregate->secondsPerMillionRows,
+            insertSecondsPerMillionRows: $this->insertAggregate->secondsPerMillionRows,
+            loopSecondsPerMillionRows: $this->loopAggregate->secondsPerMillionRows,
+        ));
+    }
+
+    public function aggregate(TableRunPhase $phase): StatsPhaseAggregateData
+    {
+        return match ($phase) {
+            TableRunPhase::CountingRows => $this->oneShotAggregate($this->countingRowsSeconds),
+            TableRunPhase::DisableFkChecks => $this->oneShotAggregate($this->disableFkSeconds),
+            TableRunPhase::Clear => $this->oneShotAggregate($this->clearTableSeconds),
+            TableRunPhase::Select => $this->selectAggregate,
+            TableRunPhase::Transform => $this->transformAggregate,
+            TableRunPhase::Insert => $this->insertAggregate,
+            TableRunPhase::Loop => $this->loopAggregate,
+        };
+    }
+
+    /**
+     * Wrap a one-shot phase duration as a single-sample aggregate. A phase that
+     * never ran (null) yields an empty (count-0) aggregate so consumers can skip it.
+     */
+    private function oneShotAggregate(?float $seconds): StatsPhaseAggregateData
+    {
+        return $seconds === null
+            ? new StatsPhaseAggregateData
+            : StatsPhaseAggregateData::withRecord($seconds, $this->totalRows);
+    }
+}

--- a/app/Data/Cloning/StatsTableTransferData.php
+++ b/app/Data/Cloning/StatsTableTransferData.php
@@ -55,6 +55,21 @@ final class StatsTableTransferData
             : null;
     }
 
+    /**
+     * Estimated wall-clock seconds until this table finishes, from the latest
+     * loop pace × outstanding rows. 0.0 once no rows remain, and 0.0 until a
+     * row total and at least one completed loop are known.
+     */
+    public float $estimatedSecondsRemaining {
+        get {
+            if ($this->rowsRemaining <= 0) {
+                return 0.0;
+            }
+
+            return $this->loopAggregate->latestPace * $this->rowsRemaining;
+        }
+    }
+
     public private(set) StatsPhaseAggregateData $selectAggregate;
 
     public private(set) StatsPhaseAggregateData $transformAggregate;
@@ -125,10 +140,10 @@ final class StatsTableTransferData
             rowsDoneCumulative: $this->rowsDone,
             rowsSkippedCumulative: $this->rowsSkipped,
             percentComplete: $this->percentComplete,
-            selectSecondsPerMillionRows: $this->selectAggregate->secondsPerMillionRows,
-            transformSecondsPerMillionRows: $this->transformAggregate->secondsPerMillionRows,
-            insertSecondsPerMillionRows: $this->insertAggregate->secondsPerMillionRows,
-            loopSecondsPerMillionRows: $this->loopAggregate->secondsPerMillionRows,
+            selectPacePerMillion: $this->selectAggregate->pacePerMillion,
+            transformPacePerMillion: $this->transformAggregate->pacePerMillion,
+            insertPacePerMillion: $this->insertAggregate->pacePerMillion,
+            loopPacePerMillion: $this->loopAggregate->pacePerMillion,
         ));
     }
 

--- a/app/Data/Cloning/TableRunPhase.php
+++ b/app/Data/Cloning/TableRunPhase.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Cloning;
+
+/**
+ * The distinct phases tracked during a single table transfer.
+ *
+ * `CountingRows` / `DisableFkChecks` / `Clear` are one-shot phases that run once
+ * before the chunk loop. `Select` / `Transform` / `Insert` are the per-chunk
+ * sub-phases, and `Loop` is the whole-loop wall-clock. `cases()` yields them in
+ * render order (one-shot first, then the per-chunk sub-phases, then `Loop`).
+ */
+enum TableRunPhase: string
+{
+    case CountingRows = 'countingRows';
+    case DisableFkChecks = 'disablingFkChecks';
+    case Clear = 'clearingData';
+
+    case Select = 'selectData';
+    case Transform = 'transformingData';
+    case Insert = 'insertingData';
+    case Loop = 'loop';
+
+    public function isOneShot(): bool
+    {
+        return match ($this) {
+            self::CountingRows, self::DisableFkChecks, self::Clear => true,
+            default => false,
+        };
+    }
+
+    /** Human-readable, present-continuous label for live progress display. */
+    public function label(): string
+    {
+        return match ($this) {
+            self::CountingRows => 'counting rows',
+            self::DisableFkChecks => 'disabling FK checks',
+            self::Clear => 'clearing data',
+            self::Select => 'selecting',
+            self::Transform => 'transforming',
+            self::Insert => 'inserting',
+            self::Loop => 'writing',
+        };
+    }
+}

--- a/app/Data/Cloning/TableRunStatus.php
+++ b/app/Data/Cloning/TableRunStatus.php
@@ -7,6 +7,7 @@ namespace App\Data\Cloning;
 enum TableRunStatus: string
 {
     case Transferred = 'transferred';
+    case InProgress = 'in_progress';
     case SkippedByFlag = 'skipped_by_flag';
     case SkippedByCascade = 'skipped_by_cascade';
     case NotFound = 'not_found';

--- a/app/Services/Cloning/CloningRunOrchestrator.php
+++ b/app/Services/Cloning/CloningRunOrchestrator.php
@@ -208,6 +208,7 @@ class CloningRunOrchestrator
                     $dumpSink,
                     $keyRemapping,
                     $config->keyRemapping,
+                    $pkColumns,
                 ), null]
                 : $this->transferTable(
                     $config->options,
@@ -322,6 +323,9 @@ class CloningRunOrchestrator
         /** @var list<SkippedRow> $skippedRows */
         $skippedRows = [];
 
+        /** @var list<array{key: string, lastValue: mixed}> $sortKeys */
+        $sortKeys = [];
+
         $stats = new StatsTableTransferData;
 
         // Only pay for the row count when a consumer actually wants per-table
@@ -360,10 +364,11 @@ class CloningRunOrchestrator
                 $tOverall = microtime(true);
                 $stats->setStatus(TableRunPhase::Select);
                 $tSelect = microtime(true);
+                $seeking = $sortKeys !== [];
+                $sql = $this->buildChunkQuery($tableConfig, $source, $offset, $chunkSize, $pkColumns, $sortKeys);
+                $bindings = $seeking ? array_map(static fn (array $k): mixed => $k['lastValue'], $sortKeys) : [];
                 /** @var list<object> $chunk */
-                $chunk = DB::connection($sourceConn)->select(
-                    $this->buildChunkQuery($tableConfig, $source, $offset, $chunkSize)
-                );
+                $chunk = DB::connection($sourceConn)->select($sql, $bindings);
                 $selectSeconds = microtime(true) - $tSelect;
 
                 if ($chunk === []) {
@@ -439,6 +444,14 @@ class CloningRunOrchestrator
 
                 ($onProgress)($tableConfig->tableName, TableRunStatus::InProgress, $rows, $skipped, [], $stats);
 
+                // Advance the keyset cursor to the last row of this chunk (if seeking).
+                if ($sortKeys !== []) {
+                    $lastRow = (array) array_last($chunk);
+                    foreach ($sortKeys as $i => $sortKey) {
+                        $sortKeys[$i]['lastValue'] = $lastRow[$sortKey['key']] ?? null;
+                    }
+                }
+
                 $offset += count($chunk);
                 $loopIndex++;
             } while (count($chunk) === $chunkSize);
@@ -470,6 +483,7 @@ class CloningRunOrchestrator
      * INSERT batches into the dump file. Mirrors transferTable() minus the live
      * target connection. Returns [rowsWritten, 0, hasFailed, failureReason, []].
      *
+     * @param  list<string>  $pkColumns
      * @return array{int, int, bool, ?string, list<SkippedRow>}
      */
     private function dumpTable(
@@ -480,6 +494,7 @@ class CloningRunOrchestrator
         SqlDumpService $dumpSink,
         ?KeyRemappingService $keyRemapping = null,
         ?KeyRemappingConfigData $keyRemappingConfig = null,
+        array $pkColumns = [],
     ): array {
         $sourceConn = $this->connector->open($source);
 
@@ -487,12 +502,16 @@ class CloningRunOrchestrator
         $offset = 0;
         $chunkSize = $options->chunkSize;
 
+        /** @var list<array{key: string, lastValue: mixed}> $sortKeys */
+        $sortKeys = [];
+
         try {
             do {
+                $seeking = $sortKeys !== [];
+                $sql = $this->buildChunkQuery($tableConfig, $source, $offset, $chunkSize, $pkColumns, $sortKeys);
+                $bindings = $seeking ? array_map(static fn (array $k): mixed => $k['lastValue'], $sortKeys) : [];
                 /** @var list<object> $chunk */
-                $chunk = DB::connection($sourceConn)->select(
-                    $this->buildChunkQuery($tableConfig, $source, $offset, $chunkSize)
-                );
+                $chunk = DB::connection($sourceConn)->select($sql, $bindings);
 
                 if ($chunk === []) {
                     break;
@@ -501,6 +520,14 @@ class CloningRunOrchestrator
                 $transformed = $this->transformChunk($chunk, $tableConfig, $engine, $keyRemapping, $keyRemappingConfig);
                 $dumpSink->writeRows($tableConfig->tableName, $transformed);
                 $rows += count($transformed);
+
+                if ($sortKeys !== []) {
+                    $lastRow = (array) array_last($chunk);
+                    foreach ($sortKeys as $i => $sortKey) {
+                        $sortKeys[$i]['lastValue'] = $lastRow[$sortKey['key']] ?? null;
+                    }
+                }
+
                 $offset += count($chunk);
             } while (count($chunk) === $chunkSize);
 
@@ -601,7 +628,117 @@ class CloningRunOrchestrator
         }
     }
 
-    private function buildChunkQuery(TableCloningConfigData $config, ConnectionData $source, int $offset, int $limit): string
+    /**
+     * Build the SELECT for the next chunk.
+     *
+     * When the driver and row strategy allow keyset (seek) pagination and the source
+     * has a usable ordering, `$sortKeys` is populated with the ordering columns on the
+     * first call (each `lastValue` null) and the caller fills every `lastValue` from the
+     * last fetched row before the next call; the query then seeks past that row with a
+     * bound row-value comparison instead of a growing OFFSET. When keyset does not apply
+     * (no PK, SQL Server) `$sortKeys` is cleared and the legacy LIMIT/OFFSET SQL is used.
+     *
+     * @param  list<string>  $pkColumns
+     * @param  list<array{key: string, lastValue: mixed}>  $sortKeys  by-reference seek cursor
+     */
+    private function buildChunkQuery(TableCloningConfigData $config, ConnectionData $source, int $offset, int $limit, array $pkColumns, array &$sortKeys): string
+    {
+        $keyColumns = $this->keysetColumns($config, $source->type, $pkColumns);
+
+        // Keyset not applicable → legacy OFFSET pagination.
+        if ($keyColumns === []) {
+            $sortKeys = [];
+
+            return $this->offsetChunkQuery($config, $source, $offset, $limit);
+        }
+
+        $rows = $config->rows;
+        $quotedTable = $this->quoteTable($config->tableName, $source->type);
+        $direction = $rows->strategy === 'last' ? 'DESC' : 'ASC';
+        $orderBy = implode(', ', array_map(
+            fn (string $c): string => $this->quoteIdentifier($c, $source->type).' '.$direction,
+            $keyColumns,
+        ));
+
+        // Respect the row-strategy limit for the ordered (non-full) strategies.
+        $chunkLimit = $limit;
+        if ($rows->strategy !== 'full') {
+            $totalLimit = $rows->limit ?? PHP_INT_MAX;
+            $chunkLimit = min($limit, max(0, $totalLimit - $offset));
+
+            if ($chunkLimit <= 0) {
+                $sortKeys = [];
+
+                return sprintf('SELECT * FROM %s WHERE 1=0', $quotedTable);
+            }
+        }
+
+        // First call: establish the cursor columns and page from the start (no WHERE).
+        if ($sortKeys === []) {
+            $sortKeys = array_map(static fn (string $c): array => ['key' => $c, 'lastValue' => null], $keyColumns);
+
+            return sprintf('SELECT * FROM %s ORDER BY %s LIMIT %d', $quotedTable, $orderBy, $chunkLimit);
+        }
+
+        // Subsequent calls: seek past the last fetched row via a bound row-value comparison.
+        $columns = implode(', ', array_map(fn (array $k): string => $this->quoteIdentifier($k['key'], $source->type), $sortKeys));
+        $placeholders = implode(', ', array_fill(0, count($sortKeys), '?'));
+        $operator = $direction === 'DESC' ? '<' : '>';
+
+        return sprintf(
+            'SELECT * FROM %s WHERE (%s) %s (%s) ORDER BY %s LIMIT %d',
+            $quotedTable,
+            $columns,
+            $operator,
+            $placeholders,
+            $orderBy,
+            $chunkLimit,
+        );
+    }
+
+    /**
+     * The ordering columns to seek by, or [] when keyset pagination does not apply
+     * (SQL Server, or no primary key to guarantee a total order).
+     *
+     * @param  list<string>  $pkColumns
+     * @return list<string>
+     */
+    private function keysetColumns(TableCloningConfigData $config, DatabaseConnectionType $type, array $pkColumns): array
+    {
+        if ($pkColumns === [] || ! $this->supportsKeysetPagination($type)) {
+            return [];
+        }
+
+        if ($config->rows->strategy === 'full') {
+            return $pkColumns;
+        }
+
+        // Ordered strategies: sort column first, PK columns appended as a tiebreaker so
+        // the ordering is total even when the sort column has duplicate values.
+        $keys = [$config->rows->sortBy ?? 'id'];
+        foreach ($pkColumns as $pk) {
+            if (! in_array($pk, $keys, true)) {
+                $keys[] = $pk;
+            }
+        }
+
+        return $keys;
+    }
+
+    private function supportsKeysetPagination(DatabaseConnectionType $type): bool
+    {
+        return in_array($type, [
+            DatabaseConnectionType::Mysql,
+            DatabaseConnectionType::MariaDB,
+            DatabaseConnectionType::PostgreSQL,
+            DatabaseConnectionType::Sqlite,
+        ], true);
+    }
+
+    /**
+     * Legacy LIMIT/OFFSET (or OFFSET/FETCH) chunk query — used when keyset does not apply.
+     */
+    private function offsetChunkQuery(TableCloningConfigData $config, ConnectionData $source, int $offset, int $limit): string
     {
         $table = $config->tableName;
         $rows = $config->rows;
@@ -635,6 +772,11 @@ class CloningRunOrchestrator
     }
 
     private function quoteTable(string $name, DatabaseConnectionType $driver): string
+    {
+        return $this->quoteIdentifier($name, $driver);
+    }
+
+    private function quoteIdentifier(string $name, DatabaseConnectionType $driver): string
     {
         return match ($driver) {
             DatabaseConnectionType::Mysql, DatabaseConnectionType::MariaDB => '`'.$name.'`',

--- a/app/Services/Cloning/CloningRunOrchestrator.php
+++ b/app/Services/Cloning/CloningRunOrchestrator.php
@@ -9,7 +9,10 @@ use App\Data\Cloning\CloningOptionsData;
 use App\Data\Cloning\ColumnCloningConfigData;
 use App\Data\Cloning\KeyRemappingConfigData;
 use App\Data\Cloning\RunResultData;
+use App\Data\Cloning\StatsLoopData;
+use App\Data\Cloning\StatsTableTransferData;
 use App\Data\Cloning\TableCloningConfigData;
+use App\Data\Cloning\TableRunPhase;
 use App\Data\Cloning\TableRunResultData;
 use App\Data\Cloning\TableRunStatus;
 use App\Data\ConnectionData;
@@ -36,8 +39,14 @@ class CloningRunOrchestrator
     /**
      * @param  list<string>  $skipTables  Tables to exclude (already validated as mutually exclusive with onlyTables)
      * @param  list<string>  $onlyTables  If non-empty, only these tables are transferred
-     * @param  callable(string, TableRunStatus, int, int, list<SkippedRow>): void  $onProgress
+     * @param  callable(string, TableRunStatus, int, int, list<SkippedRow>, ?StatsTableTransferData=): void  $onProgress
      * @param  (callable(string): void)|null  $onTableStart  Optional. Fires once per table that enters `transferTable()`, regardless of whether the transfer ultimately succeeds (`Transferred`) or fails (`Failed`). Does NOT fire for tables resolved as `SkippedByFlag`, `SkippedByCascade`, `NotFound`, or `SkippedBySchemaFailure`.
+     * @param  (callable(int): void)|null  $onStart  Optional. Fires exactly once, before the transfer loop, with the number of tables the loop will iterate. Note: when `$breakOnFailure` aborts early, fewer terminal `onProgress` events fire than this count. Useful for sizing an overall progress bar.
+     *
+     * The `$onProgress` `$timings` argument is a live, mutable object reused across
+     * every event for a table — read it synchronously inside the callback; do not
+     * retain the reference expecting a point-in-time snapshot.
+     * @param  bool  $trackRowTotals  When true, run a `SELECT COUNT(*)` per table (respecting the row limit) to size per-table progress. Off by default so non-interactive runs don't pay for a count nobody consumes.
      */
     public function run(
         CloningConfigData $config,
@@ -52,6 +61,8 @@ class CloningRunOrchestrator
         bool $breakOnFailure = false,
         ?callable $onTableStart = null,
         ?SqlDumpService $dumpSink = null,
+        ?callable $onStart = null,
+        bool $trackRowTotals = false,
     ): RunResultData {
         $start = microtime(true);
         $tableNames = array_map(static fn (TableCloningConfigData $t): string => $t->tableName, $config->tables);
@@ -75,6 +86,12 @@ class CloningRunOrchestrator
         ));
 
         $sortedTables = $this->resolver->sort($sourceSchema, $remaining);
+
+        // Announce the number of tables that will be attempted (each emits a
+        // terminal onProgress event) so callers can size an overall progress bar.
+        if ($onStart !== null) {
+            $onStart(count($sortedTables));
+        }
 
         // Replicate schema if not skipping
         /** @var array<string, string> $schemaFailures */
@@ -182,8 +199,8 @@ class CloningRunOrchestrator
                 ))
                 : [];
 
-            [$rows, $skipped, $failed, $reason, $skippedRows] = $dumpSink instanceof SqlDumpService
-                ? $this->dumpTable(
+            [$rows, $skipped, $failed, $reason, $skippedRows, $timings] = $dumpSink instanceof SqlDumpService
+                ? [...$this->dumpTable(
                     $config->options,
                     $tableConfig,
                     $source,
@@ -191,7 +208,7 @@ class CloningRunOrchestrator
                     $dumpSink,
                     $keyRemapping,
                     $config->keyRemapping,
-                )
+                ), null]
                 : $this->transferTable(
                     $config->options,
                     $tableConfig,
@@ -201,6 +218,8 @@ class CloningRunOrchestrator
                     $engine,
                     $keyRemapping,
                     $config->keyRemapping,
+                    $onProgress,
+                    $trackRowTotals,
                 );
 
             $tableDuration = microtime(true) - $tableStart;
@@ -217,7 +236,7 @@ class CloningRunOrchestrator
             $tableResults[] = new TableRunResultData($tableName, $status, $rows, $skipped, $tableDuration, $reason);
             $totalRows += $rows;
             $totalSkipped += $skipped;
-            ($onProgress)($tableName, $status, $rows, $skipped, $skippedRows);
+            ($onProgress)($tableName, $status, $rows, $skipped, $skippedRows, $timings);
 
             if ($failed && $breakOnFailure) {
                 break;
@@ -273,10 +292,10 @@ class CloningRunOrchestrator
     }
 
     /**
-     * Transfer a single table. Returns [rowsTransferred, rowsSkipped, hasFailed, failureReason, skippedRows].
+     * Transfer a single table. Returns [rowsTransferred, rowsSkipped, hasFailed, failureReason, skippedRows, timings].
      *
      * @param  list<string>  $pkColumns
-     * @return array{int, int, bool, ?string, list<SkippedRow>}
+     * @return array{int, int, bool, ?string, list<SkippedRow>, StatsTableTransferData}
      */
     private function transferTable(
         CloningOptionsData $options,
@@ -285,9 +304,12 @@ class CloningRunOrchestrator
         ConnectionData $target,
         array $pkColumns,
         AnonymizationEngine $engine,
-        ?KeyRemappingService $keyRemapping = null,
-        ?KeyRemappingConfigData $keyRemappingConfig = null,
+        ?KeyRemappingService $keyRemapping,
+        ?KeyRemappingConfigData $keyRemappingConfig,
+        callable $onProgress,
+        bool $trackRowTotals = false,
     ): array {
+
         $sourceConn = $this->connector->open($source);
         $targetConn = $this->connector->open($target);
 
@@ -300,31 +322,68 @@ class CloningRunOrchestrator
         /** @var list<SkippedRow> $skippedRows */
         $skippedRows = [];
 
+        $stats = new StatsTableTransferData;
+
+        // Only pay for the row count when a consumer actually wants per-table
+        // progress totals; otherwise skip it (totalRows stays 0 → indeterminate).
+        if ($trackRowTotals) {
+            $stats->setStatus(TableRunPhase::CountingRows);
+            ($onProgress)($tableConfig->tableName, TableRunStatus::InProgress, $rows, $skipped, $skippedRows, $stats);
+
+            $tCount = microtime(true);
+            $stats->setTotalRows($this->countSourceRows($sourceConn, $tableConfig, $source));
+            $stats->recordCountingRows(microtime(true) - $tCount);
+        }
+
+        $loopIndex = 0;
+
         try {
             if ($options->disableForeignKeyChecks) {
+                $stats->setStatus(TableRunPhase::DisableFkChecks);
+                ($onProgress)($tableConfig->tableName, TableRunStatus::InProgress, $rows, $skipped, $skippedRows, $stats);
+
+                $t0 = microtime(true);
                 $this->disableFkChecks($targetConn, $target);
+                $stats->recordDisableFk(microtime(true) - $t0);
             }
 
             if ($tableConfig->rows->clear !== ClearMode::None) {
+                $stats->setStatus(TableRunPhase::Clear);
+                ($onProgress)($tableConfig->tableName, TableRunStatus::InProgress, $rows, $skipped, $skippedRows, $stats);
+
+                $t0 = microtime(true);
                 $this->clearTable($targetConn, $tableConfig->tableName, $tableConfig->rows->clear, $target);
+                $stats->recordClearTable(microtime(true) - $t0);
             }
 
             do {
+                $tOverall = microtime(true);
+                $stats->setStatus(TableRunPhase::Select);
+                $tSelect = microtime(true);
                 /** @var list<object> $chunk */
                 $chunk = DB::connection($sourceConn)->select(
                     $this->buildChunkQuery($tableConfig, $source, $offset, $chunkSize)
                 );
+                $selectSeconds = microtime(true) - $tSelect;
 
                 if ($chunk === []) {
                     break;
                 }
 
+                $stats->setStatus(TableRunPhase::Transform);
+                $tTransform = microtime(true);
                 $transformed = $this->transformChunk($chunk, $tableConfig, $engine, $keyRemapping, $keyRemappingConfig);
+                $transformSeconds = microtime(true) - $tTransform;
 
+                $chunkRowsAttempted = count($transformed);
+                $loopRowsDone = 0;
+                $loopRowsSkipped = 0;
+                $stats->setStatus(TableRunPhase::Insert);
+                $insertStart = microtime(true);
                 // Bulk insert into target
                 try {
                     DB::connection($targetConn)->table($tableConfig->tableName)->insert($transformed);
-                    $rows += count($transformed);
+                    $loopRowsDone = $chunkRowsAttempted;
                 } catch (Throwable $bulkError) {
                     if ($firstInsertError === null) {
                         $firstInsertError = $bulkError->getMessage();
@@ -334,9 +393,9 @@ class CloningRunOrchestrator
                     foreach ($transformed as $rowIndexInChunk => $row) {
                         try {
                             DB::connection($targetConn)->table($tableConfig->tableName)->insert($row);
-                            $rows++;
+                            $loopRowsDone++;
                         } catch (Throwable $rowError) {
-                            $skipped++;
+                            $loopRowsSkipped++;
                             /** @var array<string, mixed> $sourceRow */
                             $sourceRow = (array) $chunk[$rowIndexInChunk];
                             $pkSnapshot = $this->extractPkSnapshot($sourceRow, $pkColumns);
@@ -359,7 +418,29 @@ class CloningRunOrchestrator
                     }
                 }
 
+                $insertSeconds = microtime(true) - $insertStart;
+
+                $rows += $loopRowsDone;
+                $skipped += $loopRowsSkipped;
+
+                $overallSeconds = microtime(true) - $tOverall;
+
+                $stats->recordLoop(new StatsLoopData(
+                    loopIndex: $loopIndex,
+                    chunkRows: $chunkRowsAttempted,
+                    selectSeconds: $selectSeconds,
+                    transformSeconds: $transformSeconds,
+                    insertSeconds: $insertSeconds,
+                    overallSeconds: $overallSeconds,
+                    rowsDone: $loopRowsDone,
+                    rowsSkipped: $loopRowsSkipped,
+                    totalRows: $stats->totalRows,
+                ));
+
+                ($onProgress)($tableConfig->tableName, TableRunStatus::InProgress, $rows, $skipped, [], $stats);
+
                 $offset += count($chunk);
+                $loopIndex++;
             } while (count($chunk) === $chunkSize);
 
             if ($rows === 0 && $skipped > 0) {
@@ -368,12 +449,12 @@ class CloningRunOrchestrator
                     $reason .= sprintf(': %s', $firstInsertError);
                 }
 
-                return [0, $skipped, true, $reason, $skippedRows];
+                return [0, $skipped, true, $reason, $skippedRows, $stats];
             }
 
-            return [$rows, $skipped, false, null, $skippedRows];
+            return [$rows, $skipped, false, null, $skippedRows, $stats];
         } catch (Throwable $throwable) {
-            return [$rows, $skipped, true, $throwable->getMessage(), $skippedRows];
+            return [$rows, $skipped, true, $throwable->getMessage(), $skippedRows, $stats];
         } finally {
             if ($options->disableForeignKeyChecks) {
                 $this->enableFkChecks($targetConn, $target);
@@ -489,6 +570,35 @@ class CloningRunOrchestrator
         }
 
         return $snapshot === [] ? null : $snapshot;
+    }
+
+    /**
+     * Best-effort SELECT COUNT(*) on the source table respecting the row
+     * strategy limit. Returns 0 on failure so progress stays optional.
+     */
+    private function countSourceRows(string $sourceConn, TableCloningConfigData $config, ConnectionData $source): int
+    {
+        try {
+            $quoted = $this->quoteTable($config->tableName, $source->type);
+            $result = DB::connection($sourceConn)->selectOne(sprintf('SELECT COUNT(*) AS c FROM %s', $quoted));
+            $count = 0;
+            if (is_object($result) && property_exists($result, 'c') && is_numeric($result->c)) {
+                $count = (int) $result->c;
+            } elseif (is_array($result) && array_key_exists('c', $result) && is_numeric($result['c'])) {
+                $count = (int) $result['c'];
+            }
+
+            $limit = $config->rows->limit;
+            if ($limit !== null && $limit >= 0 && $limit < $count) {
+                return $limit;
+            }
+
+            return $count;
+        } catch (Throwable $throwable) {
+            Log::warning('source_row_count_failed', ['table' => $config->tableName, 'error' => $throwable->getMessage()]);
+
+            return 0;
+        }
     }
 
     private function buildChunkQuery(TableCloningConfigData $config, ConnectionData $source, int $offset, int $limit): string

--- a/app/Services/Cloning/CloningYamlLoader.php
+++ b/app/Services/Cloning/CloningYamlLoader.php
@@ -68,6 +68,7 @@ class CloningYamlLoader
             dropExtraColumns: (bool) ($optionsRaw['drop_extra_columns'] ?? false),
             disableForeignKeyChecks: (bool) ($optionsRaw['disable_foreign_key_checks'] ?? true),
             fakerLocale: is_string($optionsRaw['faker_locale'] ?? null) ? $optionsRaw['faker_locale'] : 'en_US',
+            remapKeys: (bool) ($optionsRaw['remap_keys'] ?? true),
         );
 
         /** @var array<string, mixed> $tablesRaw */

--- a/app/Services/Cloning/CloningYamlValidator.php
+++ b/app/Services/Cloning/CloningYamlValidator.php
@@ -126,6 +126,11 @@ class CloningYamlValidator
             $errors[] = "Field 'options.drop_extra_columns' must be a boolean";
         }
 
+        // remap_keys is optional (defaults to true); validate type only when present
+        if (array_key_exists('remap_keys', $options) && ! is_bool($options['remap_keys'])) {
+            $errors[] = "Field 'options.remap_keys' must be a boolean";
+        }
+
         if (! array_key_exists('faker_locale', $options) || ! is_string($options['faker_locale'])) {
             $errors[] = "Field 'options.faker_locale' must be a string";
         }

--- a/app/Services/Cloning/CloningYamlValidator.php
+++ b/app/Services/Cloning/CloningYamlValidator.php
@@ -144,6 +144,13 @@ class CloningYamlValidator
         foreach ($tables as $tableName => $tableConfig) {
             $prefix = sprintf("Table '%s'", $tableName);
 
+            // A table key may be a slash-delimited regex; reject it early if it
+            // does not compile so the user hears about it before any DB work.
+            $key = (string) $tableName;
+            if (str_starts_with($key, '/') && @preg_match($key, '') === false) {
+                $errors[] = sprintf('%s: invalid regex pattern', $prefix);
+            }
+
             if (! is_array($tableConfig)) {
                 $errors[] = sprintf('%s: must be an object', $prefix);
 

--- a/app/Services/Cloning/CloningYamlWriter.php
+++ b/app/Services/Cloning/CloningYamlWriter.php
@@ -26,6 +26,7 @@ class CloningYamlWriter
         $lines[] = sprintf('  drop_unknown_tables: %s', $result->dropUnknownTables ? 'true' : 'false');
         $lines[] = sprintf('  drop_extra_columns: %s', $result->dropExtraColumns ? 'true' : 'false');
         $lines[] = sprintf('  disable_foreign_key_checks: %s', $result->disableForeignKeyChecks ? 'true' : 'false');
+        $lines[] = sprintf('  remap_keys: %s', $result->remapKeys ? 'true' : 'false');
         $lines[] = sprintf('  faker_locale: %s', $result->fakerLocale);
         $lines[] = '';
         $lines[] = 'tables:';

--- a/app/Services/Cloning/CloningYamlWriter.php
+++ b/app/Services/Cloning/CloningYamlWriter.php
@@ -97,7 +97,7 @@ class CloningYamlWriter
                     }
 
                     $lines[] = sprintf('      %s:', $column->name);
-                    $lines[] = sprintf('        strategy: %s', $column->strategy);
+                    $lines[] = sprintf('        strategy: %s', $this->encodeYamlScalar($column->strategy));
 
                     switch ($column->strategy) {
                         case 'fake':

--- a/app/Services/Cloning/TableConfigResolver.php
+++ b/app/Services/Cloning/TableConfigResolver.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cloning;
+
+use App\Data\Cloning\CloningConfigData;
+use App\Data\Cloning\TableCloningConfigData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\TableSchemaData;
+
+/**
+ * Expands regex table keys in a cloning config against the real source schema.
+ *
+ * A key under `tables:` is either a literal table name or a slash-delimited
+ * regex (`/…/`). Regex keys are expanded to the concrete source tables they
+ * match; when several entries match the same table, the last one in YAML order
+ * wins. The result is a config whose `tables` all carry concrete table names,
+ * so the rest of the run (orchestrator, getTable(), dependency sort, audit)
+ * keeps working against literal names.
+ */
+final readonly class TableConfigResolver
+{
+    public function resolve(CloningConfigData $config, DatabaseSchemaData $schema): CloningConfigData
+    {
+        $realNames = array_map(
+            static fn (TableSchemaData $t): string => $t->name,
+            $schema->tables,
+        );
+
+        /** @var array<string, TableCloningConfigData> $resolved */
+        $resolved = [];
+
+        // 1. Expand every real table against the config entries (last match wins).
+        foreach ($realNames as $realName) {
+            $winner = null;
+
+            foreach ($config->tables as $entry) {
+                if ($this->matches($entry->tableName, $realName)) {
+                    $winner = $entry;
+                }
+            }
+
+            if ($winner instanceof TableCloningConfigData) {
+                $resolved[$realName] = new TableCloningConfigData(
+                    tableName: $realName,
+                    rows: $winner->rows,
+                    columns: $winner->columns,
+                );
+            }
+        }
+
+        // 2. Preserve literal entries that match no source table, so a mistyped
+        //    or dropped table still reports NotFound as before. (Regex keys that
+        //    match nothing were never a concrete table — drop them.)
+        foreach ($config->tables as $entry) {
+            if ($this->isRegex($entry->tableName)) {
+                continue;
+            }
+
+            $matchedReal = array_any(
+                $realNames,
+                fn (string $realName): bool => $this->matches($entry->tableName, $realName),
+            );
+
+            if ($matchedReal) {
+                continue;
+            }
+
+            if (isset($resolved[$entry->tableName])) {
+                continue;
+            }
+
+            $resolved[$entry->tableName] = $entry;
+        }
+
+        return new CloningConfigData(
+            version: $config->version,
+            connectionName: $config->connectionName,
+            options: $config->options,
+            tables: array_values($resolved),
+            keyRemapping: $config->keyRemapping,
+            skipTables: $this->resolveSkipTables($config, $realNames, array_values($resolved)),
+        );
+    }
+
+    /**
+     * @param  list<string>  $realNames
+     * @param  list<TableCloningConfigData>  $resolvedTables
+     * @return list<string>
+     */
+    private function resolveSkipTables(CloningConfigData $config, array $realNames, array $resolvedTables): array
+    {
+        /** @var list<string> $skip */
+        $skip = [];
+
+        // Carry over the configured skip list, expanding any regex entries.
+        foreach ($config->skipTables as $entry) {
+            if ($this->isRegex($entry)) {
+                foreach ($realNames as $realName) {
+                    if ($this->matches($entry, $realName) && ! in_array($realName, $skip, true)) {
+                        $skip[] = $realName;
+                    }
+                }
+
+                continue;
+            }
+
+            if (! in_array($entry, $skip, true)) {
+                $skip[] = $entry;
+            }
+        }
+
+        // Any resolved table whose winning rule is `rows.strategy: skip`.
+        foreach ($resolvedTables as $table) {
+            if ($table->rows->strategy === 'skip' && ! in_array($table->tableName, $skip, true)) {
+                $skip[] = $table->tableName;
+            }
+        }
+
+        return $skip;
+    }
+
+    /**
+     * Match a config key against a concrete table name: slash-delimited regex,
+     * otherwise a case-insensitive literal comparison.
+     */
+    private function matches(string $key, string $tableName): bool
+    {
+        if ($this->isRegex($key)) {
+            return preg_match($key, $tableName) === 1;
+        }
+
+        return strcasecmp($key, $tableName) === 0;
+    }
+
+    private function isRegex(string $key): bool
+    {
+        return str_starts_with($key, '/');
+    }
+}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,12 @@
+services:
+  php:
+    image: "wodby/php:8.5-dev-macos"
+    environment:
+      PHP_EXTENSIONS_DISABLE: 'xhprof,spx'
+    healthcheck:
+      test: ["CMD", "php", "-v"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+    volumes:
+      - .:/var/www/html

--- a/docs/cloning-yaml.md
+++ b/docs/cloning-yaml.md
@@ -153,10 +153,11 @@ Controls which rows are transferred and whether the target table is cleared firs
 #### Row strategies
 
 | Strategy | Behaviour |
-|----------|-----------|
-| `full` | Copy all rows from the source table. |
+|---------|-----------|
+| `full`  | Copy all rows from the source table. |
 | `first` | Copy the first `limit` rows (ordered by `sort_by` ascending). |
-| `last` | Copy the last `limit` rows (ordered by `sort_by` descending). |
+| `last`  | Copy the last `limit` rows (ordered by `sort_by` descending). |
+| `skip`  | Skip this table entirely. |
 
 #### `clear` values
 

--- a/docs/cloning-yaml.md
+++ b/docs/cloning-yaml.md
@@ -47,6 +47,7 @@ options:
   drop_unknown_tables: false
   drop_extra_columns: false
   disable_foreign_key_checks: true
+  remap_keys: true
   faker_locale: en_US
 ```
 
@@ -57,6 +58,7 @@ options:
 | `drop_unknown_tables` | boolean | `false` | Drop tables from the target that do not exist in the source. |
 | `drop_extra_columns` | boolean | `false` | Drop columns from existing target tables that exist in the target but not in the source. ⚠ Irreversible — see note below. |
 | `disable_foreign_key_checks` | boolean | `true` | Disable foreign-key constraint checks on the target during data transfer. Recommended when truncating or inserting out of dependency order. |
+| `remap_keys` | boolean | `true` | Generate key mappings and rewrite primary/foreign key values when remapping is configured (inline `strategy: remapping` columns or a `key_remapping:` section). Set to `false` to skip that (often expensive) step without removing the remapping definition — equivalent to `cloning:run --skip-remapping-keys`. |
 | `faker_locale` | string | `en_US` | [FakerPHP locale](https://fakerphp.github.io/localization/) applied to all `fake` column strategies. Examples: `de_DE`, `fr_FR`, `ja_JP`. |
 
 ### Schema synchronization
@@ -110,12 +112,17 @@ of tables:
 ```yaml
 tables:
   # Every monthly archive table gets the same rule
-  "/^application_logs_archive_\d{2}_\d{4}$/":
+  '/^application_logs_archive_\d{2}_\d{4}$/':
     rows:
       strategy: last
       limit: 1
       clear: delete
 ```
+
+> **Quote regex keys with single quotes.** In a double-quoted YAML scalar `\`
+> is an escape character, so `\d`, `\w`, `\.` etc. make the parser fail
+> (`Found unknown escape character "\d"`). Single quotes pass the pattern
+> through verbatim.
 
 - **Keys without a leading `/` are always literal.** There is no glob/`*`
   wildcard — use a regex instead (`.*` covers what `*` would).
@@ -125,7 +132,7 @@ tables:
 
   ```yaml
   tables:
-    "/^app_logs_.*/":            # default: keep only the newest row
+    '/^app_logs_.*/':            # default: keep only the newest row
       rows: {strategy: last, limit: 1}
     app_logs_critical:           # …but copy this one in full
       rows: {strategy: full}

--- a/docs/cloning-yaml.md
+++ b/docs/cloning-yaml.md
@@ -78,7 +78,8 @@ The three schema-control options together determine how closely the target schem
 
 ## Tables
 
-Each key under `tables` is the exact table name in the source database.
+Each key under `tables` is either the exact table name in the source database
+(a **literal**) or a **regex** that matches one or more table names.
 
 ```yaml
 tables:
@@ -98,6 +99,45 @@ tables:
       limit: 100
       sort_by: created_at
 ```
+
+### Matching table names with regex
+
+Wrap a key in `/…/` to treat it as a [PCRE regex](https://www.php.net/manual/en/reference.pcre.pattern.syntax.php)
+(trailing flags allowed, e.g. `/…/i`). At run time it is expanded against the
+actual tables in the source database, so one entry can configure a whole family
+of tables:
+
+```yaml
+tables:
+  # Every monthly archive table gets the same rule
+  "/^application_logs_archive_\d{2}_\d{4}$/":
+    rows:
+      strategy: last
+      limit: 1
+      clear: delete
+```
+
+- **Keys without a leading `/` are always literal.** There is no glob/`*`
+  wildcard — use a regex instead (`.*` covers what `*` would).
+- **Matching is case-insensitive** (both literal and regex keys).
+- **The last matching entry in the file wins.** List a broad regex first, then
+  override individual tables with a more specific regex or literal below it:
+
+  ```yaml
+  tables:
+    "/^app_logs_.*/":            # default: keep only the newest row
+      rows: {strategy: last, limit: 1}
+    app_logs_critical:           # …but copy this one in full
+      rows: {strategy: full}
+  ```
+
+- A literal key that names a table **not** present in the source is still
+  reported as *not found* during the run. A regex that matches no table is
+  simply skipped.
+
+> **Note.** Key remapping (inline `strategy: remapping` columns and the legacy
+> `key_remapping:` section) and the `--skip-tables` / `--only-tables` flags
+> operate on **literal** table names only; regex keys are not expanded for them.
 
 ### `rows`
 

--- a/docs/commands/cloning-dump.md
+++ b/docs/commands/cloning-dump.md
@@ -22,6 +22,7 @@ clonio cloning:dump [options]
 | `--drop-unknown-tables` | Set `drop_unknown_tables: true` in the generated YAML |
 | `--drop-extra-columns` | Set `drop_extra_columns: true` in the generated YAML |
 | `--no-disable-fk-checks` | Set `disable_foreign_key_checks: false` in the generated YAML |
+| `--skip-remapping-keys` | Set `remap_keys: false` in the generated YAML (key remapping stays defined but disabled) |
 | `--ci` | CI mode — suppress non-error output and require `--connection` |
 
 ## Description

--- a/docs/commands/cloning-dump.md
+++ b/docs/commands/cloning-dump.md
@@ -202,6 +202,7 @@ tables:
 | `full` | Copy all rows |
 | `first` | Copy the first N rows (requires `limit`) |
 | `last` | Copy the last N rows (requires `limit`) |
+| `skip`  | Skip this table entirely |
 
 ## PII detection
 

--- a/docs/commands/cloning-run.md
+++ b/docs/commands/cloning-run.md
@@ -26,7 +26,7 @@ clonio cloning:run <file> [options]
 | `--skip-tables=<list>` | Comma-separated list of table names to exclude from this run |
 | `--only-tables=<list>` | Comma-separated list of table names to include; all others are skipped |
 | `--audit-channel=<list>` | Comma-separated list of channel names to use for this run (overrides `audit.default` in `clonio.json`) |
-| `--skip-remapping-keys` | Skip key mapping generation and FK rewriting |
+| `--skip-remapping-keys` | Skip key mapping generation and FK rewriting. Can also be persisted in the config via `options.remap_keys: false` (see [`.cloning.yaml`](../cloning-yaml.md#options)); the run is skipped when either the flag is set or the option is `false`. |
 | `--no-memory-limit` | Remove PHP's memory limit before generating key mappings. Useful for very large databases when `--file-based` is not viable. |
 | `--file-based` | Store key mappings in AES-256-CBC encrypted temporary files instead of RAM. Keeps memory usage bounded to the size of the largest single table's mapping. |
 | `--enforce-column-types` | Override: set `enforce_column_types: true` for this run |

--- a/specs/PRD-cloning-yaml-schema.md
+++ b/specs/PRD-cloning-yaml-schema.md
@@ -63,10 +63,17 @@ options:
   enforce_column_types: false        # modify target column types if they differ
   drop_unknown_tables: false         # remove tables on target not present in source
   disable_foreign_key_checks: true   # disable FK constraints on target during transfer
+  remap_keys: true                   # optional (default true); false skips key remapping generation
   faker_locale: en_US                # FakerPHP locale for all fake strategies (BCP 47, e.g. de_DE)
 ```
 
-`cloning:dump` always writes all five fields. When editing by hand, all five must remain present.
+`cloning:dump` writes all of these fields. The five core fields
+(`chunk_size`, `enforce_column_types`, `drop_unknown_tables`,
+`disable_foreign_key_checks`, `faker_locale`) are required when editing by hand;
+`remap_keys` is optional and defaults to `true`. Setting `remap_keys: false`
+skips key-mapping generation and PK/FK rewriting even when a remapping
+configuration is present — equivalent to `cloning:run --skip-remapping-keys`,
+and settable at dump time via `cloning:dump --skip-remapping-keys`.
 
 ### 4.3 `tables.<table_name>`
 
@@ -83,10 +90,12 @@ tables:
   regex that matches nothing is skipped.
 - Regex keys are **not** expanded for key remapping or the
   `--skip-tables` / `--only-tables` flags — those remain literal-only.
+- Quote regex keys with **single** quotes; in double quotes YAML treats `\` as
+  an escape, so patterns containing `\d`, `\w`, etc. fail to parse.
 
 ```yaml
 tables:
-  "/^application_logs_archive_\d{2}_\d{4}$/":   # regex: all monthly archives
+  '/^application_logs_archive_\d{2}_\d{4}$/':   # regex: all monthly archives
     rows:
       strategy: last
       limit: 1
@@ -427,6 +436,14 @@ A YAML language server hint can be placed at the top of every generated file:
         "disable_foreign_key_checks": {
           "type": "boolean",
           "description": "Disable FK constraint checks on the target during data transfer."
+        },
+        "drop_extra_columns": {
+          "type": "boolean",
+          "description": "Optional (default false). Drop columns on the target that are absent in the source."
+        },
+        "remap_keys": {
+          "type": "boolean",
+          "description": "Optional (default true). Generate key mappings and rewrite PK/FK values; false skips remapping even when configured."
         },
         "faker_locale": {
           "type": "string",

--- a/specs/PRD-cloning-yaml-schema.md
+++ b/specs/PRD-cloning-yaml-schema.md
@@ -70,8 +70,28 @@ options:
 
 ### 4.3 `tables.<table_name>`
 
+A `tables` key is either a **literal** table name or a **regex** (a key wrapped
+in `/…/`, trailing flags allowed). Regex keys are expanded against the actual
+source tables at run time, so a single entry can configure a whole family of
+tables:
+
+- Keys without a leading `/` are always literal — there is no glob/`*` wildcard.
+- Matching is case-insensitive for both literal and regex keys.
+- When several entries match the same table, the **last** entry in file order
+  wins (list a broad regex first, then override specific tables below it).
+- A literal key naming an absent source table is still reported *not found*; a
+  regex that matches nothing is skipped.
+- Regex keys are **not** expanded for key remapping or the
+  `--skip-tables` / `--only-tables` flags — those remain literal-only.
+
 ```yaml
 tables:
+  "/^application_logs_archive_\d{2}_\d{4}$/":   # regex: all monthly archives
+    rows:
+      strategy: last
+      limit: 1
+      clear: delete
+
   users:
     rows:
       strategy: full     # required; full | first | last — no default

--- a/tests/Feature/Commands/Cloning/DumpCommandTest.php
+++ b/tests/Feature/Commands/Cloning/DumpCommandTest.php
@@ -609,6 +609,37 @@ it('writes disable_foreign_key_checks: false when --no-disable-fk-checks flag is
     expect($yaml)->toContain('disable_foreign_key_checks: false');
 });
 
+it('writes remap_keys: false when --skip-remapping-keys flag is set', function (): void {
+    Storage::fake('local');
+
+    $connection = makeDumpMysqlConnection('production-db');
+    $schema = makeSimpleSchema();
+    $piiSet = makePiiMatcherSet();
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('exists')->andReturn(true);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn($connection);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn($schema);
+
+    $piiLoader = Mockery::mock(PiiMatcherLoader::class);
+    $piiLoader->shouldReceive('load')->andReturn($piiSet);
+
+    $this->app->instance(ConfigService::class, $config);
+    $this->app->instance(SchemaInspector::class, $inspector);
+    $this->app->instance(PiiMatcherLoader::class, $piiLoader);
+
+    $this->artisan('cloning:dump', [
+        '--connection' => 'production-db',
+        '--skip-remapping-keys' => true,
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+
+    $yaml = Storage::disk('local')->get('production-db.cloning.yaml');
+    expect($yaml)->toContain('remap_keys: false');
+});
+
 it('prompts for transfer options interactively and writes the chosen values', function (): void {
     Storage::fake('local');
 
@@ -635,13 +666,15 @@ it('prompts for transfer options interactively and writes the chosen values', fu
         ->expectsConfirmation('    Drop unknown tables on target?', 'no')
         ->expectsConfirmation('    Drop extra columns on target?', 'no')
         ->expectsConfirmation('    Disable foreign key checks?', 'yes')
+        ->expectsConfirmation('    Remap keys?', 'yes')
         ->assertExitCode(ExitCode::Success->value);
 
     $yaml = Storage::disk('local')->get('production-db.cloning.yaml');
     expect($yaml)
         ->toContain('enforce_column_types: true')
         ->toContain('drop_unknown_tables: false')
-        ->toContain('disable_foreign_key_checks: true');
+        ->toContain('disable_foreign_key_checks: true')
+        ->toContain('remap_keys: true');
 });
 
 it('interactive: prompts to select a connection from the choice list', function (): void {
@@ -675,6 +708,7 @@ it('interactive: prompts to select a connection from the choice list', function 
         ->expectsConfirmation('    Drop unknown tables on target?', 'no')
         ->expectsConfirmation('    Drop extra columns on target?', 'no')
         ->expectsConfirmation('    Disable foreign key checks?', 'yes')
+        ->expectsConfirmation('    Remap keys?', 'yes')
         ->assertExitCode(ExitCode::Success->value);
 
     expect(Storage::disk('local')->exists('production-db.cloning.yaml'))->toBeTrue();

--- a/tests/Feature/Commands/Cloning/RunCommandTest.php
+++ b/tests/Feature/Commands/Cloning/RunCommandTest.php
@@ -1599,6 +1599,26 @@ it('completes a real full run over SQLite and prints the summary line', function
     @unlink($target);
 });
 
+it('prints the per-table timing summary at -vvv on a real run', function (): void {
+    Storage::fake('local');
+    $source = sys_get_temp_dir().'/clonio_run_src_'.uniqid().'.db';
+    $target = sys_get_temp_dir().'/clonio_run_tgt_'.uniqid().'.db';
+    makeSqliteDb($source, rows: 3);
+    makeSqliteDb($target, rows: 0);
+    writeSqliteClonioJson($source, $target);
+    Storage::disk('local')->put('test.cloning.yaml', sqliteCloningYaml());
+
+    // Live bars need a real TTY; test output is a non-decorated BufferedOutput, so
+    // -vvv takes the fallback path but still emits the per-table timing summary.
+    $this->artisan('cloning:run test.cloning.yaml --target=staging -vvv')
+        ->expectsOutputToContain('timing summary')
+        ->expectsOutputToContain('Tables:')
+        ->assertExitCode(ExitCode::Success->value);
+
+    @unlink($source);
+    @unlink($target);
+});
+
 it('renders the verbose schema-comparison phase on a real run', function (): void {
     Storage::fake('local');
     $source = sys_get_temp_dir().'/clonio_run_src_'.uniqid().'.db';

--- a/tests/Feature/Commands/Cloning/RunCommandTest.php
+++ b/tests/Feature/Commands/Cloning/RunCommandTest.php
@@ -2097,3 +2097,92 @@ it('honours --audit-channel override even without an audit config block', functi
         '--audit-channel' => 'local',
     ])->assertExitCode(ExitCode::Success->value);
 });
+
+it('skips key mapping generation when options.remap_keys is false', function (): void {
+    Storage::fake('local');
+    $yaml = str_replace(
+        '  disable_foreign_key_checks: true',
+        "  disable_foreign_key_checks: true\n  remap_keys: false",
+        makeRemappingYaml(),
+    );
+    Storage::disk('local')->put('test.cloning.yaml', $yaml);
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $config->shouldReceive('load')->andReturn(['connections' => []]);
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn(makeRunSimpleSchema());
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    // Gate must short-circuit before any mapping is generated.
+    $remapping = Mockery::mock(KeyRemappingService::class);
+    $remapping->shouldNotReceive('generateMappings');
+    $this->app->instance(KeyRemappingService::class, $remapping);
+
+    $result = new RunResultData(
+        success: true,
+        tables: [new TableRunResultData('users', TableRunStatus::Transferred, 1, 0, 1.0, null)],
+        totalRows: 1,
+        skippedRows: 0,
+        durationSeconds: 1.0,
+        failureReason: null,
+    );
+    $orchestrator = Mockery::mock(CloningRunOrchestrator::class);
+    $orchestrator->shouldReceive('run')->andReturn($result);
+    $this->app->instance(CloningRunOrchestrator::class, $orchestrator);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+});
+
+it('generates key mappings when options.remap_keys is true (default)', function (): void {
+    Storage::fake('local');
+    Storage::disk('local')->put('test.cloning.yaml', makeRemappingYaml());
+
+    $config = Mockery::mock(ConfigService::class);
+    $config->shouldReceive('getConnection')->with('production-db')->andReturn(makeRunMysqlConnection());
+    $config->shouldReceive('getConnection')->with('staging')->andReturn(makeRunTargetConnection());
+    $config->shouldReceive('load')->andReturn(['connections' => []]);
+    $this->app->instance(ConfigService::class, $config);
+
+    $connector = Mockery::mock(DatabaseConnectionService::class);
+    $connector->shouldReceive('open')->andReturn('test_conn');
+    $this->app->instance(DatabaseConnectionService::class, $connector);
+
+    $inspector = Mockery::mock(SchemaInspector::class);
+    $inspector->shouldReceive('inspect')->andReturn(makeRunSimpleSchema());
+    $this->app->instance(SchemaInspector::class, $inspector);
+
+    $remapping = Mockery::mock(KeyRemappingService::class);
+    $remapping->shouldReceive('generateMappings')->once()->andReturn(['users' => 1]);
+    $remapping->shouldReceive('cleanup')->andReturnNull();
+    $this->app->instance(KeyRemappingService::class, $remapping);
+
+    $result = new RunResultData(
+        success: true,
+        tables: [new TableRunResultData('users', TableRunStatus::Transferred, 1, 0, 1.0, null)],
+        totalRows: 1,
+        skippedRows: 0,
+        durationSeconds: 1.0,
+        failureReason: null,
+    );
+    $orchestrator = Mockery::mock(CloningRunOrchestrator::class);
+    $orchestrator->shouldReceive('run')->andReturn($result);
+    $this->app->instance(CloningRunOrchestrator::class, $orchestrator);
+
+    $this->artisan('cloning:run', [
+        'file' => 'test.cloning.yaml',
+        '--target' => 'staging',
+        '--ci' => true,
+    ])->assertExitCode(ExitCode::Success->value);
+});

--- a/tests/Feature/Commands/InitCommandTest.php
+++ b/tests/Feature/Commands/InitCommandTest.php
@@ -232,40 +232,35 @@ it('does not overwrite existing audit channels on re-init', function (): void {
 
 it('returns an IO error when a new .env cannot be written', function (): void {
     // No APP_KEY anywhere -> the command tries to create a fresh .env.
-    // Making the disk root read-only forces Storage::put() to fail, which
-    // bubbles up as a RuntimeException and is reported as an IO error.
+    // Forcing Storage::put() to return false (as it would on a failed write)
+    // bubbles up as a RuntimeException and is reported as an IO error. We mock
+    // rather than chmod because chmod is a no-op under root (e.g. in Docker).
     putenv('APP_KEY');
     unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
 
-    $root = Storage::path('');
-    chmod($root, 0500);
+    Storage::shouldReceive('exists')->with('.env')->andReturn(false);
+    Storage::shouldReceive('put')->with('.env', Mockery::type('string'))->andReturn(false);
 
-    try {
-        $this->artisan('init')
-            ->expectsOutputToContain('permission denied')
-            ->assertExitCode(ExitCode::IoError->value);
-    } finally {
-        chmod($root, 0755);
-    }
+    $this->artisan('init')
+        ->expectsOutputToContain('permission denied')
+        ->assertExitCode(ExitCode::IoError->value);
 });
 
 it('returns an IO error when an existing .env cannot be overwritten', function (): void {
     // An existing .env without an APP_KEY would normally be appended to, but
-    // making the file itself read-only forces the write to fail.
+    // forcing Storage::put() to return false makes the rewrite fail. We mock
+    // rather than chmod because chmod is a no-op under root (e.g. in Docker).
     putenv('APP_KEY');
     unset($_ENV['APP_KEY'], $_SERVER['APP_KEY']);
 
-    Storage::put('.env', "DB_HOST=localhost\n");
-    $path = Storage::path('.env');
-    chmod($path, 0400);
+    Storage::shouldReceive('exists')->with('.env')->andReturn(true);
+    Storage::shouldReceive('get')->with('.env')->andReturn("DB_HOST=localhost\n");
+    Storage::shouldReceive('path')->with('.env')->andReturn('/tmp/clonio-readonly.env');
+    Storage::shouldReceive('put')->with('.env', Mockery::type('string'))->andReturn(false);
 
-    try {
-        $this->artisan('init')
-            ->expectsOutputToContain('permission denied')
-            ->assertExitCode(ExitCode::IoError->value);
-    } finally {
-        chmod($path, 0644);
-    }
+    $this->artisan('init')
+        ->expectsOutputToContain('permission denied')
+        ->assertExitCode(ExitCode::IoError->value);
 });
 
 it('returns an IO error when an existing .env cannot be read', function (): void {

--- a/tests/Unit/Data/Cloning/CloningDtoTest.php
+++ b/tests/Unit/Data/Cloning/CloningDtoTest.php
@@ -25,6 +25,7 @@ it('CloningOptionsData stores all fields correctly', function (): void {
     expect($opts->dropUnknownTables)->toBeFalse();
     expect($opts->disableForeignKeyChecks)->toBeTrue();
     expect($opts->fakerLocale)->toBe('de_DE');
+    expect($opts->remapKeys)->toBeTrue(); // defaults to true when omitted
 });
 
 it('TableRowConfigData stores all fields correctly', function (): void {

--- a/tests/Unit/Data/Cloning/StatsTableTransferDataTest.php
+++ b/tests/Unit/Data/Cloning/StatsTableTransferDataTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\Cloning\StatsTableTransferData;
+use App\Data\Cloning\TableRunPhase;
+
+it('returns an empty (count-0) aggregate for one-shot phases that never ran', function (): void {
+    $stats = new StatsTableTransferData;
+
+    // Regression: a one-shot phase that did not execute must be skippable by
+    // consumers (count === 0), not reported as having run in 0.0 ms.
+    foreach ([TableRunPhase::CountingRows, TableRunPhase::DisableFkChecks, TableRunPhase::Clear] as $phase) {
+        expect($stats->aggregate($phase)->count)->toBe(0);
+    }
+});
+
+it('records a single-sample aggregate once a one-shot phase runs', function (): void {
+    $stats = new StatsTableTransferData;
+    $stats->setTotalRows(1000);
+    $stats->recordClearTable(0.5);
+
+    $cleared = $stats->aggregate(TableRunPhase::Clear);
+    expect($cleared->count)->toBe(1);
+    expect($cleared->sum)->toBe(0.5);
+
+    // A sibling one-shot phase that still never ran stays at count 0.
+    expect($stats->aggregate(TableRunPhase::DisableFkChecks)->count)->toBe(0);
+});

--- a/tests/Unit/Data/Cloning/StatsTableTransferDataTest.php
+++ b/tests/Unit/Data/Cloning/StatsTableTransferDataTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Data\Cloning\StatsLoopData;
 use App\Data\Cloning\StatsTableTransferData;
 use App\Data\Cloning\TableRunPhase;
 
@@ -26,4 +27,31 @@ it('records a single-sample aggregate once a one-shot phase runs', function (): 
 
     // A sibling one-shot phase that still never ran stays at count 0.
     expect($stats->aggregate(TableRunPhase::DisableFkChecks)->count)->toBe(0);
+});
+
+it('estimates remaining time from the latest loop pace', function (): void {
+    $stats = new StatsTableTransferData;
+    $stats->setTotalRows(100);
+    $stats->recordLoop(new StatsLoopData(
+        loopIndex: 0,
+        chunkRows: 10,
+        selectSeconds: 0.2,
+        transformSeconds: 0.1,
+        insertSeconds: 0.7,
+        overallSeconds: 1.0,
+        rowsDone: 10,
+        rowsSkipped: 0,
+        totalRows: 100,
+    ));
+
+    // 90 rows remaining × (1.0s / 10 rows) = 9.0s.
+    expect($stats->estimatedSecondsRemaining)->toBe(9.0);
+});
+
+it('reports a zero ETA when nothing remains or no pace is known yet', function (): void {
+    $stats = new StatsTableTransferData;
+    expect($stats->estimatedSecondsRemaining)->toBe(0.0); // nothing to do
+
+    $stats->setTotalRows(100);
+    expect($stats->estimatedSecondsRemaining)->toBe(0.0); // rows remain but no completed loop → no pace
 });

--- a/tests/Unit/Data/Cloning/TableRunPhaseTest.php
+++ b/tests/Unit/Data/Cloning/TableRunPhaseTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\Cloning\TableRunPhase;
+
+it('marks only the pre-loop phases as one-shot', function (): void {
+    expect(TableRunPhase::CountingRows->isOneShot())->toBeTrue();
+    expect(TableRunPhase::DisableFkChecks->isOneShot())->toBeTrue();
+    expect(TableRunPhase::Clear->isOneShot())->toBeTrue();
+
+    expect(TableRunPhase::Select->isOneShot())->toBeFalse();
+    expect(TableRunPhase::Transform->isOneShot())->toBeFalse();
+    expect(TableRunPhase::Insert->isOneShot())->toBeFalse();
+    expect(TableRunPhase::Loop->isOneShot())->toBeFalse();
+});
+
+it('gives every phase a human-readable label distinct from its raw value', function (): void {
+    foreach (TableRunPhase::cases() as $phase) {
+        expect($phase->label())->not->toBe('')
+            ->and($phase->label())->not->toBe($phase->value);
+    }
+
+    expect(TableRunPhase::CountingRows->label())->toBe('counting rows');
+    expect(TableRunPhase::DisableFkChecks->label())->toBe('disabling FK checks');
+});

--- a/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+++ b/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
@@ -1075,19 +1075,19 @@ it('provides TableTransferTimingsData with per-loop entries, stats-over-time and
     expect($snap1->loopsRecorded)->toBe(2);
     expect($snap1->percentComplete)->toBe(100.0);
     // Snapshot holds immutable scalars captured at record time, unaffected by later loops.
-    expect($snap0->insertSecondsPerMillionRows)->not->toBeNull();
+    expect($snap0->insertPacePerMillion)->not->toBeNull();
 
     $insertAgg = $timings->aggregate(TableRunPhase::Insert);
     expect($insertAgg->count)->toBe(2);
     expect($insertAgg->min)->toBeLessThanOrEqual($insertAgg->max);
     expect($insertAgg->averageSeconds)->toBeGreaterThanOrEqual(0.0);
 
-    expect($insertAgg->secondsPerMillionRows)->not->toBeNull();
-    expect($insertAgg->latestSecondsPerMillionRows)->not->toBeNull();
+    expect($insertAgg->pacePerMillion)->not->toBeNull();
+    expect($insertAgg->latestPacePerMillion)->not->toBeNull();
 });
 
 it('returns null throughput and percent when total rows is zero on StatsTableTransferData', function (): void {
     $timings = new StatsTableTransferData;
-    expect($timings->aggregate(TableRunPhase::Insert)->secondsPerMillionRows)->toBeNull();
+    expect($timings->aggregate(TableRunPhase::Insert)->pacePerMillion)->toBeNull();
     expect($timings->percentComplete)->toBeNull();
 });

--- a/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+++ b/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
@@ -765,6 +765,63 @@ it('announces the one-shot phases via the timings status on InProgress before th
     expect($phases[2])->toBe(TableRunPhase::Insert);
 });
 
+it('uses keyset (seek) pagination instead of OFFSET when a primary key exists', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema(); // users, PK id
+    $config = new CloningConfigData(
+        version: '1',
+        connectionName: 'source',
+        options: new CloningOptionsData(
+            chunkSize: 2,
+            enforceColumnTypes: false,
+            dropUnknownTables: false,
+            dropExtraColumns: false,
+            disableForeignKeyChecks: false,
+            fakerLocale: 'en_US',
+        ),
+        tables: [
+            new TableCloningConfigData(
+                tableName: 'users',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+        ],
+    );
+
+    /** @var list<array{sql: string, bindings: array<int, mixed>}> $queries */
+    $queries = [];
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturnUsing(function (string $sql, array $bindings = []) use (&$queries): array {
+        $queries[] = ['sql' => $sql, 'bindings' => $bindings];
+
+        return match (count($queries)) {
+            1 => [(object) ['id' => 1], (object) ['id' => 2]],
+            2 => [(object) ['id' => 3]],
+            default => [],
+        };
+    });
+    DB::shouldReceive('table')->andReturnSelf();
+    DB::shouldReceive('insert')->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    makeOrchestrator()->run($config, $source, $target, $schema, true, [], [], static function (): void {});
+
+    // Two chunks: full window (2), then the trailing short window (1) which ends the loop.
+    expect($queries)->toHaveCount(2);
+
+    // First chunk: ordered + limited, no OFFSET, no WHERE, no bindings.
+    expect($queries[0]['sql'])->toContain('ORDER BY')->toContain('LIMIT')
+        ->not->toContain('OFFSET')
+        ->not->toContain('WHERE');
+    expect($queries[0]['bindings'])->toBe([]);
+
+    // Second chunk: seek past the last fetched id via a bound row-value comparison.
+    expect($queries[1]['sql'])->toContain('WHERE (`id`) > (?)')->toContain('ORDER BY')
+        ->not->toContain('OFFSET');
+    expect($queries[1]['bindings'])->toBe([2]);
+});
+
 it('does not fire onTableStart for tables skipped by --skip flag', function (): void {
     $source = makeOrchestratorConnection('source');
     $target = makeOrchestratorConnection('target');

--- a/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
+++ b/tests/Unit/Services/Cloning/CloningRunOrchestratorTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 use App\Data\Cloning\CloningConfigData;
 use App\Data\Cloning\CloningOptionsData;
+use App\Data\Cloning\StatsLoopData;
+use App\Data\Cloning\StatsTableTransferData;
 use App\Data\Cloning\TableCloningConfigData;
 use App\Data\Cloning\TableRowConfigData;
+use App\Data\Cloning\TableRunPhase;
 use App\Data\Cloning\TableRunResultData;
 use App\Data\Cloning\TableRunStatus;
 use App\Data\ConnectionData;
@@ -674,10 +677,92 @@ it('fires onTableStart exactly once before onProgress for transferred tables', f
         },
     );
 
+    // Row totals are not tracked by default, so no counting-rows event: start,
+    // then InProgress for the one chunk, then the terminal Transferred event.
     expect($events)->toBe([
         ['start', 'users'],
         ['progress', 'users'],
+        ['progress', 'users'],
     ]);
+});
+
+it('fires onStart exactly once with the planned table count before the transfer loop', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema();
+    $config = makeOrchestratorConfig();
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn([(object) ['id' => 1]], []);
+    DB::shouldReceive('table')->andReturnSelf();
+    DB::shouldReceive('insert')->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    $events = [];
+    $orchestrator = makeOrchestrator();
+    $orchestrator->run(
+        $config,
+        $source,
+        $target,
+        $schema,
+        true,
+        [],
+        [],
+        static function (string $tbl, TableRunStatus $status) use (&$events): void {
+            $events[] = ['progress', $tbl];
+        },
+        onStart: static function (int $total) use (&$events): void {
+            $events[] = ['start', $total];
+        },
+    );
+
+    // onStart fires first (before any progress), exactly once, with the number
+    // of tables that will be attempted.
+    expect($events[0])->toBe(['start', 1]);
+    expect(array_values(array_filter($events, static fn (array $e): bool => $e[0] === 'start')))
+        ->toBe([['start', 1]]);
+});
+
+it('announces the one-shot phases via the timings status on InProgress before the row loop', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema();
+    $config = makeOrchestratorConfig(clear: ClearMode::Truncate);
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('selectOne')->andReturn((object) ['c' => 1]);
+    DB::shouldReceive('select')->andReturn([(object) ['id' => 1]], []);
+    DB::shouldReceive('statement')->andReturnTrue();
+    DB::shouldReceive('table')->andReturnSelf();
+    DB::shouldReceive('insert')->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    /** @var list<TableRunPhase> $phases */
+    $phases = [];
+    $orchestrator = makeOrchestrator();
+    $orchestrator->run(
+        $config,
+        $source,
+        $target,
+        $schema,
+        true,
+        [],
+        [],
+        static function (string $tbl, TableRunStatus $status, int $rows, int $skipped, array $skippedRows, ?StatsTableTransferData $timings = null) use (&$phases): void {
+            // Read the phase at emit time (the stats object is mutated in place).
+            if ($status === TableRunStatus::InProgress && $timings?->status instanceof TableRunPhase) {
+                $phases[] = $timings->status;
+            }
+        },
+        trackRowTotals: true,
+    );
+
+    // Counting rows is announced first (before the count), then clearing the target,
+    // both ahead of the per-chunk loop phase (Insert). No FK-disable phase here.
+    expect($phases[0])->toBe(TableRunPhase::CountingRows);
+    expect($phases[1])->toBe(TableRunPhase::Clear);
+    expect($phases[0]->isOneShot())->toBeTrue();
+    expect($phases[2])->toBe(TableRunPhase::Insert);
 });
 
 it('does not fire onTableStart for tables skipped by --skip flag', function (): void {
@@ -898,4 +983,111 @@ it('preserves captured skip rows when a later chunk fetch throws', function (): 
     expect($progressArgs['tbl'])->toBe('users');
     expect($progressArgs['skippedRows'])->toHaveCount(1);
     expect($progressArgs['skippedRows'][0]->sqlError)->toBe('SQLSTATE[23000]: row failure on chunk 1');
+});
+
+it('provides TableTransferTimingsData with per-loop entries, stats-over-time and throughput to onProgress', function (): void {
+    $source = makeOrchestratorConnection('source');
+    $target = makeOrchestratorConnection('target');
+    $schema = makeOrchestratorSchema();
+    $config = new CloningConfigData(
+        version: '1',
+        connectionName: 'source',
+        options: new CloningOptionsData(
+            chunkSize: 2,
+            enforceColumnTypes: false,
+            dropUnknownTables: false,
+            dropExtraColumns: false,
+            disableForeignKeyChecks: false,
+            fakerLocale: 'en_US',
+        ),
+        tables: [
+            new TableCloningConfigData(
+                tableName: 'users',
+                rows: new TableRowConfigData(strategy: 'full', limit: null, sortBy: null, clear: ClearMode::None),
+                columns: [],
+            ),
+        ],
+    );
+
+    DB::shouldReceive('connection')->andReturnSelf();
+    DB::shouldReceive('select')->andReturn(
+        [(object) ['id' => 1], (object) ['id' => 2]],
+        [(object) ['id' => 3]],
+    );
+    DB::shouldReceive('selectOne')->andReturn((object) ['c' => 3]);
+    DB::shouldReceive('table')->andReturnSelf();
+    DB::shouldReceive('insert')->andReturnTrue();
+    DB::shouldReceive('purge')->andReturnNull();
+
+    /** @var list<array{status: TableRunStatus, rows: int, timings: ?StatsTableTransferData}> $events */
+    $events = [];
+    $orchestrator = makeOrchestrator();
+    $orchestrator->run(
+        $config,
+        $source,
+        $target,
+        $schema,
+        true,
+        [],
+        [],
+        static function (string $tbl, TableRunStatus $status, int $rows, int $skipped, array $skippedRows, ?StatsTableTransferData $timings = null) use (&$events): void {
+            $events[] = ['status' => $status, 'rows' => $rows, 'timings' => $timings];
+        },
+        trackRowTotals: true,
+    );
+
+    $pending = array_values(array_filter($events, static fn (array $e): bool => $e['status'] === TableRunStatus::InProgress));
+    $final = array_values(array_filter($events, static fn (array $e): bool => $e['status'] === TableRunStatus::Transferred));
+
+    // One InProgress for the counting-rows phase plus one per chunk (2 chunks).
+    expect($pending)->toHaveCount(3);
+    expect($final)->toHaveCount(1);
+
+    $timings = $final[0]['timings'];
+    expect($timings)->toBeInstanceOf(StatsTableTransferData::class);
+    expect($timings->totalRows)->toBe(3);
+    expect($timings->rowsDone)->toBe(3);
+    expect($timings->rowsSkipped)->toBe(0);
+    expect($timings->rowsRemaining)->toBe(0);
+    expect($timings->percentComplete)->toBe(100.0);
+
+    expect($timings->loops->count())->toBe(2);
+    expect($timings->statsOverTime->count())->toBe(2);
+
+    /** @var StatsLoopData $loop0 */
+    $loop0 = $timings->loops->get(0);
+    /** @var StatsLoopData $loop1 */
+    $loop1 = $timings->loops->get(1);
+    expect($loop0->loopIndex)->toBe(0);
+    expect($loop0->chunkRows)->toBe(2);
+    expect($loop0->rowsDone)->toBe(2);
+    expect($loop0->rowsSkipped)->toBe(0);
+    expect($loop0->totalRows)->toBe(3);
+    expect($loop1->loopIndex)->toBe(1);
+    expect($loop1->chunkRows)->toBe(1);
+    expect($loop1->rowsDone)->toBe(1);
+
+    $snap0 = $timings->statsOverTime->get(0);
+    $snap1 = $timings->statsOverTime->get(1);
+    expect($snap0->rowsDoneCumulative)->toBe(2);
+    expect($snap1->rowsDoneCumulative)->toBe(3);
+    expect($snap0->loopsRecorded)->toBe(1);
+    expect($snap1->loopsRecorded)->toBe(2);
+    expect($snap1->percentComplete)->toBe(100.0);
+    // Snapshot holds immutable scalars captured at record time, unaffected by later loops.
+    expect($snap0->insertSecondsPerMillionRows)->not->toBeNull();
+
+    $insertAgg = $timings->aggregate(TableRunPhase::Insert);
+    expect($insertAgg->count)->toBe(2);
+    expect($insertAgg->min)->toBeLessThanOrEqual($insertAgg->max);
+    expect($insertAgg->averageSeconds)->toBeGreaterThanOrEqual(0.0);
+
+    expect($insertAgg->secondsPerMillionRows)->not->toBeNull();
+    expect($insertAgg->latestSecondsPerMillionRows)->not->toBeNull();
+});
+
+it('returns null throughput and percent when total rows is zero on StatsTableTransferData', function (): void {
+    $timings = new StatsTableTransferData;
+    expect($timings->aggregate(TableRunPhase::Insert)->secondsPerMillionRows)->toBeNull();
+    expect($timings->percentComplete)->toBeNull();
 });

--- a/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlLoaderTest.php
@@ -7,6 +7,32 @@ use App\Services\Cloning\CloningYamlLoader;
 use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Storage;
 
+it('parses options.remap_keys: false', function (): void {
+    Storage::fake('local');
+
+    $yaml = <<<'YAML'
+version: "1"
+connection: production-db
+options:
+  chunk_size: 1000
+  enforce_column_types: false
+  drop_unknown_tables: false
+  disable_foreign_key_checks: true
+  remap_keys: false
+  faker_locale: en_US
+tables:
+  users:
+    rows:
+      strategy: full
+YAML;
+
+    Storage::disk('local')->put('my.cloning.yaml', $yaml);
+
+    $config = (new CloningYamlLoader)->load('my.cloning.yaml');
+
+    expect($config->options->remapKeys)->toBeFalse();
+});
+
 it('loads a valid cloning yaml file', function (): void {
     Storage::fake('local');
 
@@ -44,6 +70,7 @@ YAML;
     expect($config->options->chunkSize)->toBe(500);
     expect($config->options->enforceColumnTypes)->toBeTrue();
     expect($config->options->fakerLocale)->toBe('en_US');
+    expect($config->options->remapKeys)->toBeTrue(); // absent → defaults to true
     expect($config->tables)->toHaveCount(1);
 
     $table = $config->getTable('users');

--- a/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
@@ -854,3 +854,18 @@ it('flags an invalid regex table key', function (): void {
 
     expect($errors)->toContain("Table '/^app_logs_(unterminated/': invalid regex pattern");
 });
+
+it('accepts options.remap_keys when boolean', function (): void {
+    $config = makeValidConfig();
+    $config['options']['remap_keys'] = false;
+
+    expect((new CloningYamlValidator)->validate($config))->toBe([]);
+});
+
+it('flags options.remap_keys when not a boolean', function (): void {
+    $config = makeValidConfig();
+    $config['options']['remap_keys'] = 'nope';
+
+    expect((new CloningYamlValidator)->validate($config))
+        ->toContain("Field 'options.remap_keys' must be a boolean");
+});

--- a/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlValidatorTest.php
@@ -832,3 +832,25 @@ it('flags a foreign key entry that is not an object and one missing its column',
         ->toContain('key_remapping.tables[0].foreign_keys[0]: must be an object')
         ->toContain("key_remapping.tables[0].foreign_keys[1]: 'column' is required");
 });
+
+it('accepts a valid regex table key', function (): void {
+    $config = makeValidConfig();
+    $config['tables'] = [
+        '/^application_logs_archive_\d{2}_\d{4}$/' => ['rows' => ['strategy' => 'last', 'limit' => 1]],
+    ];
+
+    $errors = (new CloningYamlValidator)->validate($config);
+
+    expect($errors)->toBe([]);
+});
+
+it('flags an invalid regex table key', function (): void {
+    $config = makeValidConfig();
+    $config['tables'] = [
+        '/^app_logs_(unterminated/' => ['rows' => ['strategy' => 'full']],
+    ];
+
+    $errors = (new CloningYamlValidator)->validate($config);
+
+    expect($errors)->toContain("Table '/^app_logs_(unterminated/': invalid regex pattern");
+});

--- a/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
@@ -8,8 +8,11 @@ use App\Data\Cloning\KeyRemappingConfigData;
 use App\Data\Cloning\KeyRemappingTableData;
 use App\Data\Cloning\TableDumpData;
 use App\Enums\KeyRemappingStrategy;
+use App\Services\Cloning\CloningYamlLoader;
+use App\Services\Cloning\CloningYamlValidator;
 use App\Services\Cloning\CloningYamlWriter;
 use Illuminate\Support\Facades\Storage;
+use Symfony\Component\Yaml\Yaml;
 
 function makeDumpResult(string $connectionName = 'production-db', array $tables = []): DumpResultData
 {
@@ -58,6 +61,24 @@ function makeKeepColumn(string $name): ColumnDumpData
         staticValue: null,
         piiDetected: false,
         piiCategory: null,
+    );
+}
+
+function makeNullColumn(string $name): ColumnDumpData
+{
+    return new ColumnDumpData(
+        name: $name,
+        strategy: 'null',
+        fakerMethod: null,
+        fakerArguments: [],
+        maskChar: null,
+        visibleChars: null,
+        preserveFormat: null,
+        hashAlgorithm: null,
+        hashSalt: null,
+        staticValue: null,
+        piiDetected: true,
+        piiCategory: 'Gender',
     );
 }
 
@@ -164,6 +185,50 @@ it('writes fake strategy column with faker_method and arguments', function (): v
     expect($yaml)->toContain('faker_arguments: []');
     // keep columns should NOT appear
     expect($yaml)->not->toContain('id:');
+});
+
+it('quotes the null strategy so YAML does not parse it as a null literal', function (): void {
+    $writer = new CloningYamlWriter;
+    $table = new TableDumpData(
+        name: 'users',
+        columns: [makeNullColumn('gender')],
+        rowStrategy: 'full',
+        rowLimit: null,
+        sortBy: null,
+    );
+
+    $yaml = $writer->write(makeDumpResult('prod', [$table]));
+
+    expect($yaml)->toContain('strategy: "null"');
+});
+
+it('produces a null-strategy column that round-trips as the string "null" and validates', function (): void {
+    Storage::fake('local');
+    $writer = new CloningYamlWriter;
+    $table = new TableDumpData(
+        name: 'users',
+        columns: [makeNullColumn('gender')],
+        rowStrategy: 'full',
+        rowLimit: null,
+        sortBy: null,
+    );
+
+    $yaml = $writer->write(makeDumpResult('prod', [$table]));
+    Storage::disk('local')->put('x.cloning.yaml', $yaml);
+
+    // Regression: previously the unquoted `strategy: null` loaded as PHP null and
+    // was silently coerced to 'keep' — the column would not be nulled.
+    $config = (new CloningYamlLoader)->load('x.cloning.yaml');
+    expect($config->getTable('users')?->getColumn('gender')?->strategy)->toBe('null');
+
+    // …and it also failed Phase-1 validation (`strategy must be one of: …`).
+    $parsed = Yaml::parse($yaml);
+    expect($parsed)->toBeArray();
+
+    if (is_array($parsed)) {
+        /** @var array<string, mixed> $parsed */
+        expect((new CloningYamlValidator)->validate($parsed))->toBe([]);
+    }
 });
 
 it('writes hash strategy column with algorithm and salt', function (): void {

--- a/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
+++ b/tests/Unit/Services/Cloning/CloningYamlWriterTest.php
@@ -116,6 +116,7 @@ it('writes options block with all required fields', function (): void {
     expect($yaml)->toContain('enforce_column_types: false');
     expect($yaml)->toContain('drop_unknown_tables: false');
     expect($yaml)->toContain('disable_foreign_key_checks: true');
+    expect($yaml)->toContain('remap_keys: true');
     expect($yaml)->toContain('faker_locale: en_US');
 });
 
@@ -131,6 +132,7 @@ it('writes non-default options when overridden in DumpResultData', function (): 
         dropUnknownTables: true,
         dropExtraColumns: true,
         disableForeignKeyChecks: false,
+        remapKeys: false,
     );
 
     $yaml = $writer->write($result);
@@ -139,7 +141,8 @@ it('writes non-default options when overridden in DumpResultData', function (): 
         ->toContain('enforce_column_types: true')
         ->toContain('drop_unknown_tables: true')
         ->toContain('drop_extra_columns: true')
-        ->toContain('disable_foreign_key_checks: false');
+        ->toContain('disable_foreign_key_checks: false')
+        ->toContain('remap_keys: false');
 });
 
 it('writes fake strategy column with faker_method and arguments', function (): void {

--- a/tests/Unit/Services/Cloning/TableConfigResolverTest.php
+++ b/tests/Unit/Services/Cloning/TableConfigResolverTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\Cloning\CloningConfigData;
+use App\Data\Cloning\CloningOptionsData;
+use App\Data\Cloning\TableCloningConfigData;
+use App\Data\Cloning\TableRowConfigData;
+use App\Data\Schema\DatabaseSchemaData;
+use App\Data\Schema\TableSchemaData;
+use App\Enums\ClearMode;
+use App\Services\Cloning\TableConfigResolver;
+
+/**
+ * @param  list<string>  $names
+ */
+function schemaWith(array $names): DatabaseSchemaData
+{
+    return new DatabaseSchemaData(
+        databaseName: 'test',
+        tables: array_map(
+            static fn (string $name): TableSchemaData => new TableSchemaData($name, [], []),
+            $names,
+        ),
+    );
+}
+
+/**
+ * @param  list<TableCloningConfigData>  $tables
+ * @param  list<string>  $skip
+ */
+function configWith(array $tables, array $skip = []): CloningConfigData
+{
+    return new CloningConfigData(
+        version: '1',
+        connectionName: 'source',
+        options: new CloningOptionsData(1000, false, false, false, true, 'en_US'),
+        tables: $tables,
+        keyRemapping: null,
+        skipTables: $skip,
+    );
+}
+
+function tableEntry(string $name, string $strategy = 'full', ?int $limit = null): TableCloningConfigData
+{
+    return new TableCloningConfigData(
+        tableName: $name,
+        rows: new TableRowConfigData(strategy: $strategy, limit: $limit, sortBy: null, clear: ClearMode::None),
+        columns: [],
+    );
+}
+
+it('expands a regex key to every matching source table', function (): void {
+    $config = configWith([
+        tableEntry('/^application_logs_archive_\d{2}_\d{4}$/', 'last', 1),
+    ]);
+
+    $schema = schemaWith([
+        'application_logs_archive_02_2026',
+        'application_logs_archive_03_2026',
+        'application_logs_archive_04_2026',
+        'users',
+    ]);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    $names = array_map(fn (TableCloningConfigData $t): string => $t->tableName, $resolved->tables);
+
+    expect($names)->toBe([
+        'application_logs_archive_02_2026',
+        'application_logs_archive_03_2026',
+        'application_logs_archive_04_2026',
+    ]);
+
+    foreach ($resolved->tables as $table) {
+        expect($table->rows->strategy)->toBe('last');
+        expect($table->rows->limit)->toBe(1);
+    }
+});
+
+it('lets the last matching entry win over an earlier regex', function (): void {
+    $config = configWith([
+        tableEntry('/^app_logs_.*/', 'last', 1),
+        tableEntry('app_logs_critical', 'full'),
+    ]);
+
+    $schema = schemaWith(['app_logs_2026', 'app_logs_critical']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    $byName = [];
+    foreach ($resolved->tables as $table) {
+        $byName[$table->tableName] = $table;
+    }
+
+    expect($byName['app_logs_2026']->rows->strategy)->toBe('last');
+    expect($byName['app_logs_critical']->rows->strategy)->toBe('full');
+});
+
+it('preserves a literal entry absent from the source for NotFound reporting', function (): void {
+    $config = configWith([
+        tableEntry('users'),
+        tableEntry('legacy_orders'),
+    ]);
+
+    $schema = schemaWith(['users']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    $names = array_map(fn (TableCloningConfigData $t): string => $t->tableName, $resolved->tables);
+
+    expect($names)->toContain('users');
+    expect($names)->toContain('legacy_orders');
+});
+
+it('drops a regex key that matches nothing', function (): void {
+    $config = configWith([
+        tableEntry('/^no_such_.*/', 'last', 1),
+        tableEntry('users'),
+    ]);
+
+    $schema = schemaWith(['users']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    $names = array_map(fn (TableCloningConfigData $t): string => $t->tableName, $resolved->tables);
+
+    expect($names)->toBe(['users']);
+});
+
+it('ignores source tables that match no config entry', function (): void {
+    $config = configWith([tableEntry('users')]);
+
+    $schema = schemaWith(['users', 'sessions', 'cache']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    $names = array_map(fn (TableCloningConfigData $t): string => $t->tableName, $resolved->tables);
+
+    expect($names)->toBe(['users']);
+});
+
+it('expands a regex skip:strategy rule into concrete skipTables', function (): void {
+    $config = configWith([
+        tableEntry('/^tmp_.*/', 'skip'),
+        tableEntry('users'),
+    ]);
+
+    $schema = schemaWith(['tmp_a', 'tmp_b', 'users']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    expect($resolved->skipTables)->toContain('tmp_a');
+    expect($resolved->skipTables)->toContain('tmp_b');
+});
+
+it('expands a regex entry in the top-level skip list', function (): void {
+    $config = configWith([tableEntry('users')], ['/^tmp_.*/']);
+
+    $schema = schemaWith(['tmp_a', 'tmp_b', 'users']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    expect($resolved->skipTables)->toContain('tmp_a');
+    expect($resolved->skipTables)->toContain('tmp_b');
+});
+
+it('matches literal keys case-insensitively', function (): void {
+    $config = configWith([tableEntry('Users')]);
+
+    $schema = schemaWith(['users']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    expect($resolved->tables)->toHaveCount(1);
+    expect($resolved->tables[0]->tableName)->toBe('users');
+});
+
+it('leaves an all-literal config behaviourally unchanged', function (): void {
+    $config = configWith([
+        tableEntry('users', 'full'),
+        tableEntry('audit_logs', 'first', 100),
+    ]);
+
+    $schema = schemaWith(['users', 'audit_logs']);
+
+    $resolved = (new TableConfigResolver)->resolve($config, $schema);
+
+    $byName = [];
+    foreach ($resolved->tables as $table) {
+        $byName[$table->tableName] = $table;
+    }
+
+    expect($byName)->toHaveKeys(['users', 'audit_logs']);
+    expect($byName['users']->rows->strategy)->toBe('full');
+    expect($byName['audit_logs']->rows->strategy)->toBe('first');
+    expect($byName['audit_logs']->rows->limit)->toBe(100);
+});


### PR DESCRIPTION
## Summary

Fixes a bug where the `null` column strategy (set a column to SQL NULL) is
written **unquoted** into a generated `.cloning.yaml`, so the next `cloning:run`
fails validation.

> **Stacked PR — base: `feat/remapping-keys-as-config-option`** · 6th of 6 · Part of #164.
> No code dependency on #165–#168 (stacked only)

## The bug

The PII baseline defines a `null` strategy
(`gender: { transformation: { strategy: 'null' } }`). `cloning:dump` serialized
it with a bare `sprintf`, emitting the string `"null"` **unquoted** —
`strategy: null`. YAML reads that as the null literal, not `"null"`, so the next
`cloning:run` aborts in Phase-1 validation:

```
Table '…', column 'gender': strategy must be one of:
keep, fake, hash, mask, null, static, template, remapping
```

(Even bypassing validation, the loader coerced the null literal to `keep`, so
the column wouldn't be nulled.)

## The fix

`CloningYamlWriter` now serializes the column strategy through its existing
`encodeYamlScalar()` helper, which already quotes values colliding with YAML
literals (`null`, `true`, …). It emits `strategy: "null"`, which round-trips as
the string `"null"` — validation passes and `AnonymizationEngine` maps `'null'`
to SQL NULL. Other strategies are unchanged. One-line change scoped to the buggy
line, general for any future literal-colliding value.

## Testing

`CloningYamlWriterTest` adds a `null`-strategy case: asserts the quoted output,
and a **round-trip regression** — the written YAML loads back with
`strategy === 'null'` (not `'keep'`) and `CloningYamlValidator` returns no
errors. Verified end-to-end: `gender` dumps as `strategy: "null"`, `cloning:run`
validates and completes, target column is `NULL`.
